### PR TITLE
Add first tests mainly related to the home page

### DIFF
--- a/fedora_software/fixtures/fedora_software_testing.json
+++ b/fedora_software/fixtures/fedora_software_testing.json
@@ -1,0 +1,34261 @@
+[
+{
+    "fields": {
+        "pkgname": "0ad",
+        "type_id": "0ad.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND BSD-3-Clause AND MIT AND IPL-1.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1
+},
+{
+    "fields": {
+        "pkgname": "4Pane",
+        "type_id": "4Pane.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            3,
+            4,
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 2
+},
+{
+    "fields": {
+        "pkgname": "Add64",
+        "type_id": "Add64.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 3
+},
+{
+    "fields": {
+        "pkgname": "google-android-emoji-fonts",
+        "type_id": "AndroidEmoji",
+        "keywords": [],
+        "project_license": "Apache-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 4
+},
+{
+    "fields": {
+        "pkgname": "BlockOutII",
+        "type_id": "BlockOutII.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            10
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 5
+},
+{
+    "fields": {
+        "pkgname": "cmake-gui",
+        "type_id": "CMake.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause AND MIT AND Zlib",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 6
+},
+{
+    "fields": {
+        "pkgname": "CardManager",
+        "type_id": "CardManager.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            1
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 7
+},
+{
+    "fields": {
+        "pkgname": "CriticalMass",
+        "type_id": "CriticalMass.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 8
+},
+{
+    "fields": {
+        "pkgname": "fbreader",
+        "type_id": "FBReader.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            14
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 9
+},
+{
+    "fields": {
+        "pkgname": "FlightGear",
+        "type_id": "FlightGear.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            15
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 10
+},
+{
+    "fields": {
+        "pkgname": "gnusim8085",
+        "type_id": "GNUSim8085.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            16
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 11
+},
+{
+    "fields": {
+        "pkgname": "gameconqueror",
+        "type_id": "GameConqueror.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 12
+},
+{
+    "fields": {
+        "pkgname": "gammaray",
+        "type_id": "GammaRay.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 13
+},
+{
+    "fields": {
+        "pkgname": "IQmol",
+        "type_id": "IQmol.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause AND GPL-2.0+ AND GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            17,
+            18,
+            19,
+            20,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 14
+},
+{
+    "fields": {
+        "pkgname": "typemade-josefinsansstd-light-fonts",
+        "type_id": "Josefin",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 15
+},
+{
+    "fields": {
+        "pkgname": "kgoldrunner",
+        "type_id": "KGoldrunner.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 16
+},
+{
+    "fields": {
+        "pkgname": "kmail",
+        "type_id": "KMail2.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            13,
+            22,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 17
+},
+{
+    "fields": {
+        "pkgname": "knode",
+        "type_id": "KNode.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            24
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 18
+},
+{
+    "fields": {
+        "pkgname": "kontact",
+        "type_id": "Kontact.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 19
+},
+{
+    "fields": {
+        "pkgname": "lato-fonts",
+        "type_id": "Lato",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 20
+},
+{
+    "fields": {
+        "pkgname": "liberation-fonts-common",
+        "type_id": "Liberation",
+        "keywords": [],
+        "project_license": "Liberation",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 21
+},
+{
+    "fields": {
+        "pkgname": "libreatlas",
+        "type_id": "LibreAtlas.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            25
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 22
+},
+{
+    "fields": {
+        "pkgname": "Maelstrom",
+        "type_id": "Maelstrom.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND CC-BY-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 23
+},
+{
+    "fields": {
+        "pkgname": "hugin",
+        "type_id": "PTBatcherGUI.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 24
+},
+{
+    "fields": {
+        "pkgname": "Panini",
+        "type_id": "Panini.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 25
+},
+{
+    "fields": {
+        "pkgname": "polybori-gui",
+        "type_id": "PolyGUI.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 26
+},
+{
+    "fields": {
+        "pkgname": "PyMca",
+        "type_id": "PyMca.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            20,
+            21,
+            28
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 27
+},
+{
+    "fields": {
+        "pkgname": "RemoteBox",
+        "type_id": "RemoteBox.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            29
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 28
+},
+{
+    "fields": {
+        "pkgname": "oflb-roadstencil-fonts",
+        "type_id": "RoadStencil",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 29
+},
+{
+    "fields": {
+        "pkgname": "rodent",
+        "type_id": "Rodent.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 30
+},
+{
+    "fields": {
+        "pkgname": "Saaghar",
+        "type_id": "Saaghar.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            31
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 31
+},
+{
+    "fields": {
+        "pkgname": "scite",
+        "type_id": "SciTE.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            11,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 32
+},
+{
+    "fields": {
+        "pkgname": "oflb-sportrop-fonts",
+        "type_id": "Sportrop",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 33
+},
+{
+    "fields": {
+        "pkgname": "Thunar",
+        "type_id": "Thunar.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            3,
+            4,
+            5,
+            30,
+            33
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 34
+},
+{
+    "fields": {
+        "pkgname": "tzclock",
+        "type_id": "TzClock.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            5,
+            34
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 35
+},
+{
+    "fields": {
+        "pkgname": "httrack",
+        "type_id": "WebHTTrack.desktop",
+        "keywords": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 36
+},
+{
+    "fields": {
+        "pkgname": "yagf",
+        "type_id": "YAGF.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            26,
+            35,
+            36
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 37
+},
+{
+    "fields": {
+        "pkgname": "aajohan-comfortaa-fonts",
+        "type_id": "aajohan-comfortaa",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 38
+},
+{
+    "fields": {
+        "pkgname": "abattis-cantarell-fonts",
+        "type_id": "abattis-cantarell",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 39
+},
+{
+    "fields": {
+        "pkgname": "abe",
+        "type_id": "abe.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 40
+},
+{
+    "fields": {
+        "pkgname": "abiword",
+        "type_id": "abiword.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            37
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 41
+},
+{
+    "fields": {
+        "pkgname": "accerciser",
+        "type_id": "accerciser.desktop",
+        "keywords": [
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,
+            29,
+            30,
+            31,
+            32,
+            33,
+            34,
+            35,
+            36,
+            37,
+            38,
+            39,
+            40,
+            41,
+            42,
+            43,
+            44,
+            45,
+            46,
+            47,
+            48,
+            49,
+            50,
+            51,
+            52,
+            53,
+            54,
+            55,
+            56,
+            57,
+            58,
+            59,
+            60,
+            61,
+            62,
+            63,
+            64,
+            65,
+            66,
+            67,
+            68,
+            69,
+            70,
+            71,
+            72,
+            73,
+            74,
+            75,
+            76,
+            77,
+            78,
+            79,
+            80,
+            81,
+            82,
+            83,
+            84,
+            85,
+            86,
+            87,
+            88,
+            89,
+            90,
+            91,
+            92,
+            93,
+            94,
+            95,
+            96,
+            97,
+            98,
+            99,
+            100,
+            101,
+            102,
+            103,
+            104,
+            105,
+            106,
+            107,
+            108,
+            109,
+            110,
+            111,
+            112,
+            113,
+            114,
+            115,
+            116,
+            117,
+            118,
+            119,
+            120,
+            121,
+            122,
+            123,
+            124,
+            125,
+            126,
+            127,
+            128
+        ],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            11,
+            38
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 42
+},
+{
+    "fields": {
+        "pkgname": "adf-accanthis-2-fonts",
+        "type_id": "adf-accanthis",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 43
+},
+{
+    "fields": {
+        "pkgname": "adf-gillius-2-fonts",
+        "type_id": "adf-gillius",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 44
+},
+{
+    "fields": {
+        "pkgname": "adf-tribun-fonts",
+        "type_id": "adf-tribun",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 45
+},
+{
+    "fields": {
+        "pkgname": "adobe-source-code-pro-fonts",
+        "type_id": "adobe-source-code-pro",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 46
+},
+{
+    "fields": {
+        "pkgname": "aeskulap",
+        "type_id": "aeskulap.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26,
+            39
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 47
+},
+{
+    "fields": {
+        "pkgname": "akonadiconsole",
+        "type_id": "akonadiconsole.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 48
+},
+{
+    "fields": {
+        "pkgname": "akregator",
+        "type_id": "akregator.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            24
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 49
+},
+{
+    "fields": {
+        "pkgname": "aldusleaf-crimson-text-fonts",
+        "type_id": "aldusleaf-crimson-text",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 50
+},
+{
+    "fields": {
+        "pkgname": "ht-alegreya-fonts",
+        "type_id": "alegreya",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 51
+},
+{
+    "fields": {
+        "pkgname": "alexandria",
+        "type_id": "alexandria.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            40
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 52
+},
+{
+    "fields": {
+        "pkgname": "alienarena",
+        "type_id": "alienarena.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 53
+},
+{
+    "fields": {
+        "pkgname": "allgeyer-fonts-common",
+        "type_id": "allgeyer",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 54
+},
+{
+    "fields": {
+        "pkgname": "almanah",
+        "type_id": "almanah.desktop",
+        "keywords": [
+            129,
+            130
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 55
+},
+{
+    "fields": {
+        "pkgname": "almas-mongolian-title-fonts",
+        "type_id": "almas-mongolian-title",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 56
+},
+{
+    "fields": {
+        "pkgname": "alt-ergo-gui",
+        "type_id": "alt-ergo.desktop",
+        "keywords": [],
+        "project_license": "CECILL-C",
+        "type": "desktop",
+        "categories": [
+            11,
+            42
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 57
+},
+{
+    "fields": {
+        "pkgname": "amarok",
+        "type_id": "amarok.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 OR GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 58
+},
+{
+    "fields": {
+        "pkgname": "amoebax",
+        "type_id": "amoebax.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND ClArtistic",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 59
+},
+{
+    "fields": {
+        "pkgname": "anjuta",
+        "type_id": "anjuta.desktop",
+        "keywords": [
+            13,
+            19,
+            22,
+            26,
+            28,
+            30,
+            32,
+            36,
+            43,
+            49,
+            51,
+            57,
+            60,
+            63,
+            69,
+            71,
+            74,
+            77,
+            81,
+            83,
+            85,
+            90,
+            93,
+            96,
+            100,
+            104,
+            108,
+            113,
+            116,
+            117,
+            120,
+            125,
+            128,
+            131,
+            132,
+            133,
+            134,
+            135,
+            136,
+            137,
+            138,
+            139,
+            140,
+            141,
+            142,
+            143,
+            144,
+            145,
+            146,
+            147,
+            148,
+            149,
+            150,
+            151,
+            152,
+            153,
+            154,
+            155,
+            156,
+            157,
+            158,
+            159,
+            160,
+            161,
+            162,
+            163,
+            164,
+            165,
+            166,
+            167,
+            168,
+            169,
+            170,
+            171,
+            172,
+            173,
+            174,
+            175,
+            176,
+            177,
+            178,
+            179,
+            180,
+            181,
+            182,
+            183
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 60
+},
+{
+    "fields": {
+        "pkgname": "anki",
+        "type_id": "anki.desktop",
+        "keywords": [],
+        "project_license": "AGPL-3.0 AND GPL-3.0+ AND MIT AND BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            19,
+            46
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 61
+},
+{
+    "fields": {
+        "pkgname": "ansifilter-gui",
+        "type_id": "ansifilter.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            33,
+            47
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 62
+},
+{
+    "fields": {
+        "pkgname": "ibus-anthy-python",
+        "type_id": "anthy.xml",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 63
+},
+{
+    "fields": {
+        "pkgname": "antimicro",
+        "type_id": "antimicro.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 64
+},
+{
+    "fields": {
+        "pkgname": "antlrworks",
+        "type_id": "antlrworks.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            11,
+            45,
+            49
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 65
+},
+{
+    "fields": {
+        "pkgname": "apa-new-athena-unicode-fonts",
+        "type_id": "apa-new-athena-unicode",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 66
+},
+{
+    "fields": {
+        "pkgname": "apanov-edrip-fonts",
+        "type_id": "apanov-edrip",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 67
+},
+{
+    "fields": {
+        "pkgname": "apanov-heuristica-fonts",
+        "type_id": "apanov-heuristica",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 68
+},
+{
+    "fields": {
+        "pkgname": "setools-gui",
+        "type_id": "apol.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 69
+},
+{
+    "fields": {
+        "pkgname": "apper",
+        "type_id": "apper.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            50,
+            51
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 70
+},
+{
+    "fields": {
+        "pkgname": "apx",
+        "type_id": "apx.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            1
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 71
+},
+{
+    "fields": {
+        "pkgname": "aqemu",
+        "type_id": "aqemu.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            29
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 72
+},
+{
+    "fields": {
+        "pkgname": "arc-gui-clients",
+        "type_id": "arcstorage-ui.desktop",
+        "keywords": [],
+        "project_license": "Apache-2.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            52
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 73
+},
+{
+    "fields": {
+        "pkgname": "ardour",
+        "type_id": "ardour2.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 74
+},
+{
+    "fields": {
+        "pkgname": "ardour3",
+        "type_id": "ardour3.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 75
+},
+{
+    "fields": {
+        "pkgname": "arduino",
+        "type_id": "arduino.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            11,
+            16,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 76
+},
+{
+    "fields": {
+        "pkgname": "ark",
+        "type_id": "ark.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            53,
+            54
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 77
+},
+{
+    "fields": {
+        "pkgname": "armacycles-ad",
+        "type_id": "armacycles-ad.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 78
+},
+{
+    "fields": {
+        "pkgname": "arora",
+        "type_id": "arora.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            52
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 79
+},
+{
+    "fields": {
+        "pkgname": "artha",
+        "type_id": "artha.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            46,
+            55
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 80
+},
+{
+    "fields": {
+        "pkgname": "asc",
+        "type_id": "asc.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 81
+},
+{
+    "fields": {
+        "pkgname": "ascend",
+        "type_id": "ascend.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 82
+},
+{
+    "fields": {
+        "pkgname": "ascii-design",
+        "type_id": "ascii-design.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 83
+},
+{
+    "fields": {
+        "pkgname": "python-ase",
+        "type_id": "ase-gui.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+ AND MIT",
+        "type": "desktop",
+        "categories": [
+            18,
+            19,
+            20,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 84
+},
+{
+    "fields": {
+        "pkgname": "astromenace",
+        "type_id": "astromenace.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 85
+},
+{
+    "fields": {
+        "pkgname": "asunder",
+        "type_id": "asunder.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 86
+},
+{
+    "fields": {
+        "pkgname": "atanks",
+        "type_id": "atanks.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            2,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 87
+},
+{
+    "fields": {
+        "pkgname": "atril",
+        "type_id": "atril.desktop",
+        "keywords": [
+            184,
+            185,
+            186,
+            187,
+            188,
+            189,
+            190,
+            191,
+            192,
+            193,
+            194
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+ AND MIT",
+        "type": "desktop",
+        "categories": [
+            13,
+            14
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 88
+},
+{
+    "fields": {
+        "pkgname": "audacious-plugin-fc",
+        "type_id": "audacious-plugin-fc",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 89
+},
+{
+    "fields": {
+        "pkgname": "audacious-plugins-amidi",
+        "type_id": "audacious-plugins-amidi",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 90
+},
+{
+    "fields": {
+        "pkgname": "audacious-plugins-exotic",
+        "type_id": "audacious-plugins-exotic",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+ AND GPL-3.0 AND MIT AND BSD-3-Clause",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 91
+},
+{
+    "fields": {
+        "pkgname": "audacious-plugins-jack",
+        "type_id": "audacious-plugins-jack",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 92
+},
+{
+    "fields": {
+        "pkgname": "audacious",
+        "type_id": "audacious.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 93
+},
+{
+    "fields": {
+        "pkgname": "audacity",
+        "type_id": "audacity.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            56
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 94
+},
+{
+    "fields": {
+        "pkgname": "audex",
+        "type_id": "audex.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 95
+},
+{
+    "fields": {
+        "pkgname": "calligra-author",
+        "type_id": "author.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 96
+},
+{
+    "fields": {
+        "pkgname": "autokey-gtk",
+        "type_id": "autokey-gtk.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 97
+},
+{
+    "fields": {
+        "pkgname": "autokey-qt",
+        "type_id": "autokey-qt.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 98
+},
+{
+    "fields": {
+        "pkgname": "avahi-ui-tools",
+        "type_id": "avahi-discover.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 99
+},
+{
+    "fields": {
+        "pkgname": "avogadro",
+        "type_id": "avogadro.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            18,
+            19,
+            20,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 100
+},
+{
+    "fields": {
+        "pkgname": "backintime-kde",
+        "type_id": "backintime-kde4.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 101
+},
+{
+    "fields": {
+        "pkgname": "bacula-console-bat",
+        "type_id": "bacula-bat.desktop",
+        "keywords": [],
+        "project_license": "AGPL-3.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 102
+},
+{
+    "fields": {
+        "pkgname": "bacula-traymonitor",
+        "type_id": "bacula-traymonitor.desktop",
+        "keywords": [],
+        "project_license": "AGPL-3.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 103
+},
+{
+    "fields": {
+        "pkgname": "baekmuk-ttf-batang-fonts",
+        "type_id": "baekmuk",
+        "keywords": [],
+        "project_license": "Baekmuk",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 104
+},
+{
+    "fields": {
+        "pkgname": "ballerburg",
+        "type_id": "ballerburg.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 105
+},
+{
+    "fields": {
+        "pkgname": "ballz",
+        "type_id": "ballz.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 106
+},
+{
+    "fields": {
+        "pkgname": "balsa",
+        "type_id": "balsa.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            22
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 107
+},
+{
+    "fields": {
+        "pkgname": "banshee",
+        "type_id": "banshee.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43,
+            57
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 108
+},
+{
+    "fields": {
+        "pkgname": "barrage",
+        "type_id": "barrage.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 109
+},
+{
+    "fields": {
+        "pkgname": "batti",
+        "type_id": "batti.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 110
+},
+{
+    "fields": {
+        "pkgname": "berusky",
+        "type_id": "berusky.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 111
+},
+{
+    "fields": {
+        "pkgname": "berusky2",
+        "type_id": "berusky2.desktop",
+        "keywords": [
+            195,
+            196,
+            197,
+            198,
+            199,
+            200,
+            201
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 112
+},
+{
+    "fields": {
+        "pkgname": "beteckna-fonts-common",
+        "type_id": "beteckna",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 113
+},
+{
+    "fields": {
+        "pkgname": "bibletime",
+        "type_id": "bibletime.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            19,
+            55,
+            59
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 114
+},
+{
+    "fields": {
+        "pkgname": "bijiben",
+        "type_id": "bijiben.desktop",
+        "keywords": [
+            202,
+            203,
+            204,
+            205,
+            206,
+            207,
+            208,
+            209,
+            210,
+            211,
+            212,
+            213,
+            214,
+            215,
+            216,
+            217,
+            218,
+            219,
+            220,
+            221,
+            222,
+            223,
+            224,
+            225,
+            226,
+            227,
+            228,
+            229,
+            230,
+            231,
+            232,
+            233,
+            234,
+            235,
+            236,
+            237,
+            238,
+            239,
+            240,
+            241,
+            242,
+            243,
+            244,
+            245,
+            246,
+            247,
+            248,
+            249,
+            250,
+            251,
+            252,
+            253,
+            254,
+            255,
+            256,
+            257,
+            258,
+            259,
+            260,
+            261,
+            262,
+            263,
+            264,
+            265,
+            266,
+            267,
+            268,
+            269,
+            270,
+            271,
+            272,
+            273,
+            274,
+            275,
+            276,
+            277,
+            278,
+            279,
+            280,
+            281,
+            282,
+            283,
+            284,
+            285,
+            286,
+            287,
+            288,
+            289,
+            290,
+            291,
+            292,
+            293,
+            294,
+            295,
+            296,
+            297,
+            298,
+            299,
+            300,
+            301,
+            302,
+            303,
+            304,
+            305,
+            306,
+            307,
+            308,
+            309,
+            310,
+            311
+        ],
+        "project_license": "GPL-3.0+ AND LGPL-3.0 AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 115
+},
+{
+    "fields": {
+        "pkgname": "billiards",
+        "type_id": "billiards.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            15
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 116
+},
+{
+    "fields": {
+        "pkgname": "biloba",
+        "type_id": "biloba.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            60
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 117
+},
+{
+    "fields": {
+        "pkgname": "linux-libertine-biolinum-fonts",
+        "type_id": "biolinum",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception OR OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 118
+},
+{
+    "fields": {
+        "pkgname": "bitstream-vera-fonts-common",
+        "type_id": "bitstream-vera",
+        "keywords": [],
+        "project_license": "Bitstream Vera",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 119
+},
+{
+    "fields": {
+        "pkgname": "bleachbit",
+        "type_id": "bleachbit.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 120
+},
+{
+    "fields": {
+        "pkgname": "blender",
+        "type_id": "blender.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            26,
+            61
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 121
+},
+{
+    "fields": {
+        "pkgname": "blobby",
+        "type_id": "blobby.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 122
+},
+{
+    "fields": {
+        "pkgname": "blobwars",
+        "type_id": "blobwars.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0 AND CC-BY-3.0 AND BSD-3-Clause AND Public Domain",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 123
+},
+{
+    "fields": {
+        "pkgname": "bluefish-shared-data",
+        "type_id": "bluefish.desktop",
+        "keywords": [
+            83,
+            132,
+            137,
+            141,
+            143,
+            145,
+            148,
+            150,
+            152,
+            153,
+            160,
+            162,
+            164,
+            312,
+            313,
+            314,
+            315,
+            316,
+            317,
+            318,
+            319,
+            320,
+            321,
+            322,
+            323,
+            324,
+            325,
+            326,
+            327,
+            328,
+            329,
+            330,
+            331,
+            332,
+            333,
+            334,
+            335,
+            336,
+            337,
+            338
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            62
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 124
+},
+{
+    "fields": {
+        "pkgname": "ibus-bogo",
+        "type_id": "bogo.xml",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 125
+},
+{
+    "fields": {
+        "pkgname": "boinc-manager",
+        "type_id": "boinc-manager.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 126
+},
+{
+    "fields": {
+        "pkgname": "bpg-algeti-fonts",
+        "type_id": "bpg-algeti",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 127
+},
+{
+    "fields": {
+        "pkgname": "bpg-chveulebrivi-fonts",
+        "type_id": "bpg-chveulebrivi",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 128
+},
+{
+    "fields": {
+        "pkgname": "bpg-classic-fonts",
+        "type_id": "bpg-classic",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 129
+},
+{
+    "fields": {
+        "pkgname": "bpg-courier-fonts",
+        "type_id": "bpg-courier",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 130
+},
+{
+    "fields": {
+        "pkgname": "bpg-courier-s-fonts",
+        "type_id": "bpg-courier-s",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 131
+},
+{
+    "fields": {
+        "pkgname": "bpg-dedaena-block-fonts",
+        "type_id": "bpg-dedaena-block",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 132
+},
+{
+    "fields": {
+        "pkgname": "bpg-dejavu-sans-fonts",
+        "type_id": "bpg-dejavu-sans",
+        "keywords": [],
+        "project_license": "Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 133
+},
+{
+    "fields": {
+        "pkgname": "bpg-elite-fonts",
+        "type_id": "bpg-elite",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 134
+},
+{
+    "fields": {
+        "pkgname": "bpg-excelsior-caps-fonts",
+        "type_id": "bpg-excelsior",
+        "keywords": [],
+        "project_license": "Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 135
+},
+{
+    "fields": {
+        "pkgname": "bpg-glaho-fonts",
+        "type_id": "bpg-glaho",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 136
+},
+{
+    "fields": {
+        "pkgname": "bpg-gorda-fonts",
+        "type_id": "bpg-gorda",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 137
+},
+{
+    "fields": {
+        "pkgname": "bpg-ingiri-fonts",
+        "type_id": "bpg-ingiri",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 138
+},
+{
+    "fields": {
+        "pkgname": "bpg-irubaqidze-fonts",
+        "type_id": "bpg-irubaqidze",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 139
+},
+{
+    "fields": {
+        "pkgname": "bpg-mikhail-stephan-fonts",
+        "type_id": "bpg-mikhail-stephan",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 140
+},
+{
+    "fields": {
+        "pkgname": "bpg-mrgvlovani-caps-fonts",
+        "type_id": "bpg-mrgvlovani",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 141
+},
+{
+    "fields": {
+        "pkgname": "bpg-nateli-caps-fonts",
+        "type_id": "bpg-nateli",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 142
+},
+{
+    "fields": {
+        "pkgname": "bpg-nino-medium-cond-fonts",
+        "type_id": "bpg-nino-medium",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 143
+},
+{
+    "fields": {
+        "pkgname": "bpg-sans-fonts",
+        "type_id": "bpg-sans",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 144
+},
+{
+    "fields": {
+        "pkgname": "bpg-serif-fonts",
+        "type_id": "bpg-serif",
+        "keywords": [],
+        "project_license": "Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 145
+},
+{
+    "fields": {
+        "pkgname": "bpg-ucnobi-fonts",
+        "type_id": "bpg-ucnobi",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 146
+},
+{
+    "fields": {
+        "pkgname": "bpython",
+        "type_id": "bpython.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            5,
+            11,
+            63
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 147
+},
+{
+    "fields": {
+        "pkgname": "brasero",
+        "type_id": "brasero.desktop",
+        "keywords": [
+            339,
+            340,
+            341,
+            342,
+            343,
+            344,
+            345,
+            346,
+            347,
+            348,
+            349,
+            350,
+            351,
+            352,
+            353,
+            354,
+            355,
+            356,
+            357,
+            358,
+            359,
+            360,
+            361,
+            362,
+            363,
+            364,
+            365,
+            366,
+            367,
+            368,
+            369,
+            370,
+            371,
+            372,
+            373,
+            374,
+            375,
+            376,
+            377,
+            378,
+            379,
+            380,
+            381,
+            382,
+            383,
+            384,
+            385,
+            386,
+            387,
+            388,
+            389,
+            390,
+            391,
+            392,
+            393,
+            394,
+            395,
+            396,
+            397,
+            398,
+            399,
+            400,
+            401,
+            402,
+            403,
+            404,
+            405,
+            406,
+            407,
+            408,
+            409,
+            410,
+            411,
+            412,
+            413,
+            414,
+            415,
+            416,
+            417,
+            418,
+            419,
+            420,
+            421,
+            422,
+            423,
+            424,
+            425,
+            426,
+            427,
+            428,
+            429,
+            430,
+            431,
+            432,
+            433,
+            434,
+            435,
+            436,
+            437,
+            438,
+            439,
+            440,
+            441,
+            442,
+            443,
+            444,
+            445,
+            446,
+            447,
+            448,
+            449,
+            450,
+            451,
+            452,
+            453,
+            454,
+            455,
+            456,
+            457,
+            458,
+            459,
+            460,
+            461,
+            462,
+            463,
+            464,
+            465,
+            466,
+            467,
+            468,
+            469,
+            470,
+            471,
+            472,
+            473,
+            474,
+            475,
+            476,
+            477,
+            478,
+            479,
+            480,
+            481,
+            482,
+            483,
+            484,
+            485,
+            486,
+            487,
+            488,
+            489,
+            490,
+            491,
+            492,
+            493,
+            494,
+            495,
+            496,
+            497,
+            498,
+            499,
+            500,
+            501,
+            502,
+            503,
+            504,
+            505,
+            506,
+            507,
+            508,
+            509,
+            510,
+            511,
+            512,
+            513,
+            514,
+            515,
+            516,
+            517,
+            518,
+            519,
+            520,
+            521,
+            522,
+            523,
+            524,
+            525,
+            526,
+            527,
+            528,
+            529,
+            530,
+            531,
+            532,
+            533,
+            534,
+            535,
+            536,
+            537,
+            538,
+            539,
+            540,
+            541,
+            542,
+            543,
+            544,
+            545,
+            546,
+            547,
+            548,
+            549,
+            550,
+            551,
+            552,
+            553,
+            554,
+            555,
+            556,
+            557,
+            558,
+            559,
+            560,
+            561,
+            562,
+            563,
+            564,
+            565,
+            566,
+            567,
+            568,
+            569,
+            570,
+            571,
+            572,
+            573,
+            574,
+            575,
+            576,
+            577,
+            578,
+            579,
+            580,
+            581,
+            582,
+            583,
+            584,
+            585,
+            586,
+            587,
+            588,
+            589,
+            590,
+            591,
+            592,
+            593
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            64,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 148
+},
+{
+    "fields": {
+        "pkgname": "bristol",
+        "type_id": "bristol.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 149
+},
+{
+    "fields": {
+        "pkgname": "btanks",
+        "type_id": "btanks.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 150
+},
+{
+    "fields": {
+        "pkgname": "budgie",
+        "type_id": "budgie.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 151
+},
+{
+    "fields": {
+        "pkgname": "bustle",
+        "type_id": "bustle.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            11,
+            42,
+            66
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 152
+},
+{
+    "fields": {
+        "pkgname": "byobu",
+        "type_id": "byobu.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 153
+},
+{
+    "fields": {
+        "pkgname": "bzflag",
+        "type_id": "bzflag.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 154
+},
+{
+    "fields": {
+        "pkgname": "dconf-editor",
+        "type_id": "ca.desrt.dconf-editor.desktop",
+        "keywords": [
+            594,
+            595,
+            596,
+            597,
+            598,
+            599,
+            600,
+            601,
+            602,
+            603,
+            604,
+            605,
+            606,
+            607,
+            608,
+            609,
+            610,
+            611,
+            612,
+            613,
+            614,
+            615,
+            616,
+            617,
+            618,
+            619,
+            620,
+            621,
+            622,
+            623,
+            624,
+            625,
+            626,
+            627,
+            628,
+            629,
+            630,
+            631,
+            632,
+            633,
+            634,
+            635,
+            636,
+            637,
+            638,
+            639,
+            640,
+            641,
+            642,
+            643,
+            644,
+            645,
+            646,
+            647,
+            648,
+            649,
+            650,
+            651,
+            652,
+            653,
+            654,
+            655,
+            656,
+            657,
+            658,
+            659,
+            660,
+            661,
+            662,
+            663,
+            664,
+            665,
+            666,
+            667,
+            668,
+            669,
+            670,
+            671,
+            672,
+            673,
+            674,
+            675,
+            676,
+            677,
+            678,
+            679,
+            680,
+            681,
+            682,
+            683,
+            684,
+            685,
+            686,
+            687,
+            688,
+            689,
+            690,
+            691,
+            692,
+            693,
+            694,
+            695,
+            696,
+            697,
+            698,
+            699,
+            700,
+            701,
+            702,
+            703,
+            704,
+            705,
+            706,
+            707,
+            708,
+            709,
+            710,
+            711,
+            712,
+            713,
+            714,
+            715,
+            716,
+            717,
+            718
+        ],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 155
+},
+{
+    "fields": {
+        "pkgname": "caja",
+        "type_id": "caja-browser.desktop",
+        "keywords": [
+            184,
+            719,
+            720,
+            721
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            4,
+            5,
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 156
+},
+{
+    "fields": {
+        "pkgname": "calf",
+        "type_id": "calf.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 157
+},
+{
+    "fields": {
+        "pkgname": "calibre",
+        "type_id": "calibre-gui.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 158
+},
+{
+    "fields": {
+        "pkgname": "california",
+        "type_id": "california.desktop",
+        "keywords": [
+            722,
+            723,
+            724,
+            725,
+            726,
+            727,
+            728,
+            729,
+            730,
+            731,
+            732,
+            733,
+            734,
+            735,
+            736,
+            737,
+            738,
+            739,
+            740,
+            741,
+            742,
+            743,
+            744,
+            745,
+            746,
+            747,
+            748,
+            749,
+            750,
+            751,
+            752,
+            753,
+            754,
+            755,
+            756,
+            757,
+            758,
+            759,
+            760,
+            761,
+            762,
+            763,
+            764,
+            765,
+            766,
+            767,
+            768,
+            769,
+            770,
+            771,
+            772,
+            773,
+            774,
+            775,
+            776,
+            777,
+            778,
+            779,
+            780,
+            781,
+            782,
+            783,
+            784,
+            785,
+            786,
+            787,
+            788,
+            789,
+            790,
+            791,
+            792,
+            793,
+            794,
+            795
+        ],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            13,
+            67
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 159
+},
+{
+    "fields": {
+        "pkgname": "campivisivi-titillium-fonts",
+        "type_id": "campivisivi-titillium-fonts",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 160
+},
+{
+    "fields": {
+        "pkgname": "ibus-cangjie-engine-cangjie",
+        "type_id": "cangjie.xml",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 161
+},
+{
+    "fields": {
+        "pkgname": "cardpeek",
+        "type_id": "cardpeek.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            68
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 162
+},
+{
+    "fields": {
+        "pkgname": "catfish",
+        "type_id": "catfish.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 163
+},
+{
+    "fields": {
+        "pkgname": "cave9",
+        "type_id": "cave9.desktop",
+        "keywords": [],
+        "project_license": "LGPL-3.0 AND CC-BY-SA-3.0 AND Public Domain",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 164
+},
+{
+    "fields": {
+        "pkgname": "cbrpager",
+        "type_id": "cbrpager.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 165
+},
+{
+    "fields": {
+        "pkgname": "ccgo",
+        "type_id": "ccgo.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            60
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 166
+},
+{
+    "fields": {
+        "pkgname": "celestia",
+        "type_id": "celestia.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            69
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 167
+},
+{
+    "fields": {
+        "pkgname": "cellwriter",
+        "type_id": "cellwriter.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            38
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 168
+},
+{
+    "fields": {
+        "pkgname": "cf-bonveno-fonts",
+        "type_id": "cf-bonveno",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 169
+},
+{
+    "fields": {
+        "pkgname": "cf-sorts-mill-goudy-fonts",
+        "type_id": "cf-sorts-mill-goudy",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 170
+},
+{
+    "fields": {
+        "pkgname": "chatzilla",
+        "type_id": "chatzilla.desktop",
+        "keywords": [],
+        "project_license": "MPL-1.1 OR GPL-2.0+ OR LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            23,
+            70
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 171
+},
+{
+    "fields": {
+        "pkgname": "chemtool",
+        "type_id": "chemtool.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            18,
+            19,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 172
+},
+{
+    "fields": {
+        "pkgname": "cherrytree",
+        "type_id": "cherrytree.desktop",
+        "keywords": [
+            202,
+            796,
+            797
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 173
+},
+{
+    "fields": {
+        "pkgname": "ibus-chewing",
+        "type_id": "chewing.xml",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 174
+},
+{
+    "fields": {
+        "pkgname": "childsplay",
+        "type_id": "childsplay.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            19
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 175
+},
+{
+    "fields": {
+        "pkgname": "chinese-calendar",
+        "type_id": "chinese-calendar.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            14,
+            26,
+            71
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 176
+},
+{
+    "fields": {
+        "pkgname": "chirp",
+        "type_id": "chirp.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 177
+},
+{
+    "fields": {
+        "pkgname": "chisholm-letterslaughing-fonts",
+        "type_id": "chisholm-letterslaughing",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 178
+},
+{
+    "fields": {
+        "pkgname": "chisholm-to-be-continued-fonts",
+        "type_id": "chisholm-to-be-continued",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 179
+},
+{
+    "fields": {
+        "pkgname": "chkrootkit",
+        "type_id": "chkrootkit.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause AND GPL-2.0+ AND Python-2.0",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 180
+},
+{
+    "fields": {
+        "pkgname": "chocolate-doom",
+        "type_id": "chocolate-doom.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 181
+},
+{
+    "fields": {
+        "pkgname": "clamtk",
+        "type_id": "clamtk.desktop",
+        "keywords": [
+            798,
+            799,
+            800,
+            801,
+            802
+        ],
+        "project_license": "GPL-1.0+ OR Artistic-2.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 182
+},
+{
+    "fields": {
+        "pkgname": "claws-mail",
+        "type_id": "claws-mail.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            22,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 183
+},
+{
+    "fields": {
+        "pkgname": "clementine",
+        "type_id": "clementine.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 184
+},
+{
+    "fields": {
+        "pkgname": "clipit",
+        "type_id": "clipit.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 185
+},
+{
+    "fields": {
+        "pkgname": "cockpit",
+        "type_id": "cockpit.desktop",
+        "keywords": [
+            803,
+            804
+        ],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            4,
+            66
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 186
+},
+{
+    "fields": {
+        "pkgname": "code-editor",
+        "type_id": "code-editor.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            11,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 187
+},
+{
+    "fields": {
+        "pkgname": "codeblocks-contrib",
+        "type_id": "codeblocks-contrib",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 188
+},
+{
+    "fields": {
+        "pkgname": "codeblocks",
+        "type_id": "codeblocks.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 189
+},
+{
+    "fields": {
+        "pkgname": "colossus",
+        "type_id": "colossus.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 190
+},
+{
+    "fields": {
+        "pkgname": "colorhug-client-backlight",
+        "type_id": "com.hughski.ColorHug.Backlight.desktop",
+        "keywords": [
+            805,
+            806,
+            807,
+            808
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 191
+},
+{
+    "fields": {
+        "pkgname": "colorhug-client-ccmx",
+        "type_id": "com.hughski.ColorHug.CcmxLoader.desktop",
+        "keywords": [
+            807,
+            809
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 192
+},
+{
+    "fields": {
+        "pkgname": "colorhug-client-refresh",
+        "type_id": "com.hughski.ColorHug.DisplayAnalysis.desktop",
+        "keywords": [
+            807,
+            808,
+            810,
+            811,
+            812,
+            813,
+            814,
+            815,
+            816,
+            817,
+            818,
+            819,
+            820,
+            821,
+            822,
+            823,
+            824,
+            825
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 193
+},
+{
+    "fields": {
+        "pkgname": "colorhug-client-flash",
+        "type_id": "com.hughski.ColorHug.FlashLoader.desktop",
+        "keywords": [
+            807,
+            826,
+            827,
+            828,
+            829,
+            830,
+            831,
+            832,
+            833,
+            834,
+            835,
+            836,
+            837,
+            838,
+            839,
+            840
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 194
+},
+{
+    "fields": {
+        "pkgname": "conakry-fonts",
+        "type_id": "conakry",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 195
+},
+{
+    "fields": {
+        "pkgname": "converseen",
+        "type_id": "converseen.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 196
+},
+{
+    "fields": {
+        "pkgname": "copyq",
+        "type_id": "copyq.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 197
+},
+{
+    "fields": {
+        "pkgname": "coq-coqide",
+        "type_id": "coqide.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 198
+},
+{
+    "fields": {
+        "pkgname": "crossfire-client",
+        "type_id": "crossfire-client.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            73,
+            74
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 199
+},
+{
+    "fields": {
+        "pkgname": "culmus-aharoni-clm-fonts",
+        "type_id": "culmus",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 200
+},
+{
+    "fields": {
+        "pkgname": "cutecw",
+        "type_id": "cutecw.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            7,
+            19,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 201
+},
+{
+    "fields": {
+        "pkgname": "kicad",
+        "type_id": "cvpcb.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            16
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 202
+},
+{
+    "fields": {
+        "pkgname": "d-feet",
+        "type_id": "d-feet.desktop",
+        "keywords": [
+            841,
+            842,
+            843,
+            844,
+            845,
+            846,
+            847,
+            848,
+            849,
+            850,
+            851,
+            852,
+            853,
+            854,
+            855,
+            856,
+            857,
+            858,
+            859,
+            860,
+            861,
+            862,
+            863,
+            864,
+            865,
+            866,
+            867,
+            868,
+            869,
+            870,
+            871,
+            872,
+            873,
+            874
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            42
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 203
+},
+{
+    "fields": {
+        "pkgname": "darkgarden-fonts",
+        "type_id": "darkgarden",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 204
+},
+{
+    "fields": {
+        "pkgname": "darkplaces-quake",
+        "type_id": "darkplaces-quake.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+ AND BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 205
+},
+{
+    "fields": {
+        "pkgname": "darktable",
+        "type_id": "darktable.desktop",
+        "keywords": [
+            875,
+            876,
+            877,
+            878,
+            879,
+            880,
+            881,
+            882,
+            883,
+            884,
+            885,
+            886,
+            887,
+            888,
+            889,
+            890,
+            891,
+            892,
+            893,
+            894,
+            895,
+            896,
+            897,
+            898,
+            899,
+            900
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            75
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 206
+},
+{
+    "fields": {
+        "pkgname": "datovka",
+        "type_id": "datovka.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 207
+},
+{
+    "fields": {
+        "pkgname": "decibel-audio-player",
+        "type_id": "decibel-audio-player.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 208
+},
+{
+    "fields": {
+        "pkgname": "dejavu-fonts-common",
+        "type_id": "dejavu",
+        "keywords": [],
+        "project_license": "Bitstream Vera AND Public Domain",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 209
+},
+{
+    "fields": {
+        "pkgname": "deluge-gtk",
+        "type_id": "deluge.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0-with-GCC-exception",
+        "type": "desktop",
+        "categories": [
+            23,
+            76,
+            77
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 210
+},
+{
+    "fields": {
+        "pkgname": "denemo-feta-fonts",
+        "type_id": "denemo-feta",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 211
+},
+{
+    "fields": {
+        "pkgname": "denemo-music-fonts",
+        "type_id": "denemo-music",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 212
+},
+{
+    "fields": {
+        "pkgname": "denemo",
+        "type_id": "denemo.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            19,
+            57
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 213
+},
+{
+    "fields": {
+        "pkgname": "devassistant-gui",
+        "type_id": "devassistant.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 214
+},
+{
+    "fields": {
+        "pkgname": "devdocs-io.desktop",
+        "type_id": "devdocs-io.desktop",
+        "keywords": [
+            132,
+            901,
+            902
+        ],
+        "project_license": "Mozilla Public License v2.0",
+        "type": "webapp",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 215
+},
+{
+    "fields": {
+        "pkgname": "devhelp",
+        "type_id": "devhelp.desktop",
+        "keywords": [
+            26,
+            32,
+            38,
+            46,
+            55,
+            63,
+            77,
+            104,
+            120,
+            134,
+            136,
+            901,
+            902,
+            903,
+            904,
+            905,
+            906,
+            907,
+            908,
+            909,
+            910,
+            911,
+            912,
+            913,
+            914,
+            915,
+            916,
+            917,
+            918,
+            919,
+            920,
+            921,
+            922,
+            923,
+            924,
+            925,
+            926,
+            927,
+            928,
+            929,
+            930,
+            931,
+            932,
+            933,
+            934,
+            935,
+            936,
+            937,
+            938,
+            939,
+            940,
+            941,
+            942,
+            943,
+            944,
+            945,
+            946,
+            947,
+            948,
+            949,
+            950,
+            951,
+            952,
+            953,
+            954,
+            955,
+            956,
+            957,
+            958,
+            959,
+            960,
+            961,
+            962,
+            963,
+            964,
+            965,
+            966,
+            967,
+            968,
+            969,
+            970,
+            971,
+            972,
+            973,
+            974,
+            975,
+            976,
+            977,
+            978,
+            979,
+            980,
+            981,
+            982,
+            983,
+            984,
+            985,
+            986,
+            987,
+            988,
+            989,
+            990,
+            991,
+            992,
+            993,
+            994,
+            995,
+            996,
+            997,
+            998,
+            999,
+            1000,
+            1001,
+            1002,
+            1003,
+            1004,
+            1005,
+            1006,
+            1007,
+            1008,
+            1009,
+            1010,
+            1011,
+            1012,
+            1013,
+            1014,
+            1015,
+            1016,
+            1017,
+            1018,
+            1019,
+            1020,
+            1021,
+            1022,
+            1023,
+            1024,
+            1025,
+            1026,
+            1027,
+            1028,
+            1029,
+            1030,
+            1031,
+            1032,
+            1033,
+            1034,
+            1035,
+            1036,
+            1037,
+            1038,
+            1039,
+            1040,
+            1041,
+            1042,
+            1043,
+            1044,
+            1045,
+            1046,
+            1047,
+            1048,
+            1049,
+            1050,
+            1051,
+            1052,
+            1053,
+            1054,
+            1055,
+            1056,
+            1057,
+            1058,
+            1059,
+            1060,
+            1061,
+            1062,
+            1063,
+            1064,
+            1065,
+            1066,
+            1067,
+            1068,
+            1069,
+            1070,
+            1071,
+            1072,
+            1073,
+            1074,
+            1075,
+            1076,
+            1077,
+            1078,
+            1079,
+            1080,
+            1081,
+            1082,
+            1083,
+            1084,
+            1085,
+            1086,
+            1087,
+            1088,
+            1089,
+            1090
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 216
+},
+{
+    "fields": {
+        "pkgname": "dexter",
+        "type_id": "dexter.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0 AND GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 217
+},
+{
+    "fields": {
+        "pkgname": "dia",
+        "type_id": "dia.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 218
+},
+{
+    "fields": {
+        "pkgname": "diffuse",
+        "type_id": "diffuse.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 219
+},
+{
+    "fields": {
+        "pkgname": "digikam",
+        "type_id": "digikam.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            75
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 220
+},
+{
+    "fields": {
+        "pkgname": "dillo",
+        "type_id": "dillo.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            52
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 221
+},
+{
+    "fields": {
+        "pkgname": "din",
+        "type_id": "din.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            57,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 222
+},
+{
+    "fields": {
+        "pkgname": "kipi-plugins",
+        "type_id": "dngconverter.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Adobe",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 223
+},
+{
+    "fields": {
+        "pkgname": "dnssec-nodes",
+        "type_id": "dnssec-nodes.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            4,
+            5,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 224
+},
+{
+    "fields": {
+        "pkgname": "dolphin",
+        "type_id": "dolphin.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            3,
+            4,
+            33
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 225
+},
+{
+    "fields": {
+        "pkgname": "dreampie",
+        "type_id": "dreampie.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND LGPL-2.1+ AND BSD-3-Clause AND Python-2.0 AND Copyright only",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 226
+},
+{
+    "fields": {
+        "pkgname": "drehatlas-warender-bibliothek-fonts",
+        "type_id": "drehatlas-warender-bibliothek",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 227
+},
+{
+    "fields": {
+        "pkgname": "drehatlas-widelands-fonts",
+        "type_id": "drehatlas-widelands",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 228
+},
+{
+    "fields": {
+        "pkgname": "drehatlas-xaporho-fonts",
+        "type_id": "drehatlas-xaporho",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 229
+},
+{
+    "fields": {
+        "pkgname": "drumkv1",
+        "type_id": "drumkv1.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 230
+},
+{
+    "fields": {
+        "pkgname": "drumstick-drumgrid",
+        "type_id": "drumstick-drumgrid.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            19,
+            57,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 231
+},
+{
+    "fields": {
+        "pkgname": "drumstick-guiplayer",
+        "type_id": "drumstick-guiplayer.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            19,
+            57,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 232
+},
+{
+    "fields": {
+        "pkgname": "drumstick-vpiano",
+        "type_id": "drumstick-vpiano.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            19,
+            57,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 233
+},
+{
+    "fields": {
+        "pkgname": "dustin-domestic-manners-fonts",
+        "type_id": "dustin-domestic-manners",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 234
+},
+{
+    "fields": {
+        "pkgname": "dustin-dustismo-roman-fonts",
+        "type_id": "dustin-dustismo",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 235
+},
+{
+    "fields": {
+        "pkgname": "dvdisaster",
+        "type_id": "dvdisaster.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 236
+},
+{
+    "fields": {
+        "pkgname": "dwb",
+        "type_id": "dwb.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            52
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 237
+},
+{
+    "fields": {
+        "pkgname": "easystroke",
+        "type_id": "easystroke.desktop",
+        "keywords": [],
+        "project_license": "ISC",
+        "type": "desktop",
+        "categories": [
+            5,
+            38
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 238
+},
+{
+    "fields": {
+        "pkgname": "easytag-nautilus",
+        "type_id": "easytag-nautilus",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 239
+},
+{
+    "fields": {
+        "pkgname": "easytag",
+        "type_id": "easytag.desktop",
+        "keywords": [
+            339,
+            402,
+            442,
+            494,
+            504,
+            519,
+            541,
+            549,
+            565,
+            1091,
+            1092,
+            1093,
+            1094,
+            1095,
+            1096,
+            1097,
+            1098,
+            1099,
+            1100,
+            1101,
+            1102,
+            1103,
+            1104,
+            1105,
+            1106,
+            1107,
+            1108,
+            1109,
+            1110,
+            1111,
+            1112,
+            1113,
+            1114,
+            1115,
+            1116,
+            1117,
+            1118,
+            1119
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            56
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 240
+},
+{
+    "fields": {
+        "pkgname": "ebumeter",
+        "type_id": "ebumeter.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 241
+},
+{
+    "fields": {
+        "pkgname": "EekBoek-gui",
+        "type_id": "ebwxshell.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+ OR Artistic-1.0",
+        "type": "desktop",
+        "categories": [
+            13,
+            79
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 242
+},
+{
+    "fields": {
+        "pkgname": "ecl",
+        "type_id": "ecl.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+ AND BSD-3-Clause AND MIT AND Public Domain",
+        "type": "desktop",
+        "categories": [
+            11,
+            80
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 243
+},
+{
+    "fields": {
+        "pkgname": "eclipse-changelog",
+        "type_id": "eclipse-changelog",
+        "keywords": [],
+        "project_license": "EPL-1.0",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 244
+},
+{
+    "fields": {
+        "pkgname": "eclipse-gcov",
+        "type_id": "eclipse-gcov",
+        "keywords": [],
+        "project_license": "EPL-1.0",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 245
+},
+{
+    "fields": {
+        "pkgname": "eclipse-jdt",
+        "type_id": "eclipse-jdt",
+        "keywords": [],
+        "project_license": "EPL-1.0",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 246
+},
+{
+    "fields": {
+        "pkgname": "eclipse-pde",
+        "type_id": "eclipse-pde",
+        "keywords": [],
+        "project_license": "EPL-1.0",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 247
+},
+{
+    "fields": {
+        "pkgname": "eclipse-pdt",
+        "type_id": "eclipse-pdt",
+        "keywords": [],
+        "project_license": "EPL-1.0",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 248
+},
+{
+    "fields": {
+        "pkgname": "eclipse-quickrex",
+        "type_id": "eclipse-quickrex",
+        "keywords": [],
+        "project_license": "EPL-1.0",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 249
+},
+{
+    "fields": {
+        "pkgname": "eclipse-platform",
+        "type_id": "eclipse.desktop",
+        "keywords": [],
+        "project_license": "EPL-1.0",
+        "type": "desktop",
+        "categories": [
+            11,
+            45,
+            49
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 250
+},
+{
+    "fields": {
+        "pkgname": "ecolier-court-fonts",
+        "type_id": "ecolier-court",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 251
+},
+{
+    "fields": {
+        "pkgname": "edb",
+        "type_id": "edb.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            42
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 252
+},
+{
+    "fields": {
+        "pkgname": "edgar",
+        "type_id": "edgar.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND CC-BY-3.0 AND CC-BY-SA-3.0 AND CC0-1.0 AND GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            12,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 253
+},
+{
+    "fields": {
+        "pkgname": "eekboard",
+        "type_id": "eekboard.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 254
+},
+{
+    "fields": {
+        "pkgname": "kicad",
+        "type_id": "eeschema.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            16
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 255
+},
+{
+    "fields": {
+        "pkgname": "eiciel",
+        "type_id": "eiciel.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            33
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 256
+},
+{
+    "fields": {
+        "pkgname": "ekmukta-fonts",
+        "type_id": "ekmukta",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 257
+},
+{
+    "fields": {
+        "pkgname": "emacs-terminal",
+        "type_id": "emacs-terminal.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND CC0-1.0",
+        "type": "desktop",
+        "categories": [
+            5,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 258
+},
+{
+    "fields": {
+        "pkgname": "emacs",
+        "type_id": "emacs.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND CC0-1.0",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 259
+},
+{
+    "fields": {
+        "pkgname": "emelfm2",
+        "type_id": "emelfm2.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            3,
+            4,
+            5,
+            30,
+            33
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 260
+},
+{
+    "fields": {
+        "pkgname": "ibus-table-code",
+        "type_id": "emoji-table.db",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 261
+},
+{
+    "fields": {
+        "pkgname": "empathy",
+        "type_id": "empathy.desktop",
+        "keywords": [
+            584,
+            1072,
+            1120,
+            1121,
+            1122,
+            1123,
+            1124,
+            1125,
+            1126,
+            1127,
+            1128,
+            1129,
+            1130,
+            1131,
+            1132,
+            1133,
+            1134,
+            1135,
+            1136,
+            1137,
+            1138,
+            1139,
+            1140,
+            1141,
+            1142,
+            1143,
+            1144,
+            1145,
+            1146,
+            1147,
+            1148,
+            1149,
+            1150,
+            1151,
+            1152,
+            1153,
+            1154,
+            1155,
+            1156,
+            1157,
+            1158,
+            1159,
+            1160,
+            1161,
+            1162,
+            1163,
+            1164,
+            1165,
+            1166,
+            1167,
+            1168,
+            1169,
+            1170,
+            1171,
+            1172,
+            1173,
+            1174,
+            1175,
+            1176,
+            1177,
+            1178,
+            1179,
+            1180,
+            1181,
+            1182,
+            1183,
+            1184,
+            1185,
+            1186,
+            1187,
+            1188,
+            1189,
+            1190,
+            1191,
+            1192,
+            1193,
+            1194,
+            1195,
+            1196,
+            1197,
+            1198,
+            1199,
+            1200,
+            1201,
+            1202,
+            1203,
+            1204,
+            1205,
+            1206,
+            1207,
+            1208,
+            1209,
+            1210,
+            1211,
+            1212,
+            1213,
+            1214,
+            1215,
+            1216,
+            1217,
+            1218,
+            1219,
+            1220,
+            1221,
+            1222,
+            1223,
+            1224,
+            1225,
+            1226,
+            1227,
+            1228,
+            1229,
+            1230,
+            1231,
+            1232,
+            1233,
+            1234,
+            1235,
+            1236,
+            1237,
+            1238,
+            1239,
+            1240,
+            1241,
+            1242,
+            1243,
+            1244,
+            1245,
+            1246,
+            1247,
+            1248,
+            1249,
+            1250,
+            1251,
+            1252,
+            1253,
+            1254,
+            1255,
+            1256,
+            1257,
+            1258,
+            1259,
+            1260,
+            1261,
+            1262,
+            1263,
+            1264,
+            1265,
+            1266,
+            1267,
+            1268,
+            1269,
+            1270,
+            1271,
+            1272,
+            1273,
+            1274,
+            1275,
+            1276,
+            1277,
+            1278,
+            1279,
+            1280,
+            1281,
+            1282,
+            1283,
+            1284,
+            1285,
+            1286,
+            1287,
+            1288,
+            1289,
+            1290,
+            1291,
+            1292,
+            1293,
+            1294,
+            1295,
+            1296,
+            1297,
+            1298,
+            1299,
+            1300,
+            1301,
+            1302,
+            1303,
+            1304,
+            1305,
+            1306,
+            1307,
+            1308,
+            1309,
+            1310,
+            1311,
+            1312,
+            1313,
+            1314,
+            1315,
+            1316,
+            1317,
+            1318,
+            1319,
+            1320,
+            1321,
+            1322,
+            1323,
+            1324,
+            1325,
+            1326,
+            1327,
+            1328,
+            1329,
+            1330,
+            1331,
+            1332,
+            1333,
+            1334,
+            1335,
+            1336,
+            1337,
+            1338,
+            1339,
+            1340,
+            1341,
+            1342,
+            1343,
+            1344,
+            1345,
+            1346,
+            1347,
+            1348,
+            1349,
+            1350,
+            1351,
+            1352,
+            1353,
+            1354,
+            1355,
+            1356,
+            1357,
+            1358
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            82
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 262
+},
+{
+    "fields": {
+        "pkgname": "engauge-digitizer",
+        "type_id": "engauge-digitizer.desktop",
+        "keywords": [
+            1359,
+            1360,
+            1361
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            28
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 263
+},
+{
+    "fields": {
+        "pkgname": "engrampa",
+        "type_id": "engrampa.desktop",
+        "keywords": [
+            184,
+            721,
+            1362,
+            1363
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            5,
+            53,
+            54
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 264
+},
+{
+    "fields": {
+        "pkgname": "engrid",
+        "type_id": "engrid.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            21,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 265
+},
+{
+    "fields": {
+        "pkgname": "enigma",
+        "type_id": "enigma.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 266
+},
+{
+    "fields": {
+        "pkgname": "enlightenment-data",
+        "type_id": "enlightenment_filemanager.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            3,
+            4,
+            5,
+            30,
+            33
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 267
+},
+{
+    "fields": {
+        "pkgname": "entangle",
+        "type_id": "entangle.desktop",
+        "keywords": [
+            1364,
+            1365,
+            1366,
+            1367
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 268
+},
+{
+    "fields": {
+        "pkgname": "eog-plugin-exif-display",
+        "type_id": "eog-exif-display",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 269
+},
+{
+    "fields": {
+        "pkgname": "eog-plugin-export-to-folder",
+        "type_id": "eog-export-to-folder",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 270
+},
+{
+    "fields": {
+        "pkgname": "eog-plugin-fit-to-width",
+        "type_id": "eog-fit-to-width",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 271
+},
+{
+    "fields": {
+        "pkgname": "eog-plugin-fullscreenbg",
+        "type_id": "eog-fullscreenbg",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 272
+},
+{
+    "fields": {
+        "pkgname": "eog-plugin-hide-titlebar",
+        "type_id": "eog-hide-titlebar",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 273
+},
+{
+    "fields": {
+        "pkgname": "eog-plugin-light-theme",
+        "type_id": "eog-light-theme",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 274
+},
+{
+    "fields": {
+        "pkgname": "eog-plugin-map",
+        "type_id": "eog-map",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 275
+},
+{
+    "fields": {
+        "pkgname": "eog-plugin-maximize-windows",
+        "type_id": "eog-maximize-windows",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 276
+},
+{
+    "fields": {
+        "pkgname": "eog-plugin-postasa",
+        "type_id": "eog-postasa",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 277
+},
+{
+    "fields": {
+        "pkgname": "eog-plugin-pythonconsole",
+        "type_id": "eog-pythonconsole",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 278
+},
+{
+    "fields": {
+        "pkgname": "eog-plugin-send-by-mail",
+        "type_id": "eog-send-by-mail",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 279
+},
+{
+    "fields": {
+        "pkgname": "eog-plugin-slideshowshuffle",
+        "type_id": "eog-slideshowshuffle",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 280
+},
+{
+    "fields": {
+        "pkgname": "eog",
+        "type_id": "eog.desktop",
+        "keywords": [
+            879,
+            883,
+            1368,
+            1369,
+            1370,
+            1371,
+            1372,
+            1373,
+            1374,
+            1375,
+            1376,
+            1377,
+            1378,
+            1379,
+            1380,
+            1381,
+            1382,
+            1383,
+            1384,
+            1385,
+            1386,
+            1387,
+            1388,
+            1389,
+            1390,
+            1391,
+            1392,
+            1393,
+            1394,
+            1395,
+            1396,
+            1397,
+            1398,
+            1399,
+            1400,
+            1401,
+            1402,
+            1403,
+            1404,
+            1405,
+            1406,
+            1407,
+            1408,
+            1409,
+            1410,
+            1411,
+            1412,
+            1413,
+            1414,
+            1415,
+            1416,
+            1417,
+            1418,
+            1419,
+            1420,
+            1421,
+            1422,
+            1423,
+            1424,
+            1425,
+            1426,
+            1427,
+            1428,
+            1429,
+            1430,
+            1431,
+            1432,
+            1433,
+            1434,
+            1435,
+            1436,
+            1437,
+            1438,
+            1439,
+            1440,
+            1441,
+            1442,
+            1443,
+            1444,
+            1445,
+            1446,
+            1447,
+            1448,
+            1449,
+            1450,
+            1451,
+            1452,
+            1453,
+            1454,
+            1455,
+            1456,
+            1457,
+            1458,
+            1459,
+            1460,
+            1461,
+            1462,
+            1463,
+            1464,
+            1465,
+            1466,
+            1467,
+            1468,
+            1469,
+            1470,
+            1471,
+            1472,
+            1473,
+            1474,
+            1475,
+            1476,
+            1477,
+            1478,
+            1479,
+            1480,
+            1481,
+            1482,
+            1483,
+            1484,
+            1485,
+            1486,
+            1487,
+            1488,
+            1489,
+            1490,
+            1491,
+            1492,
+            1493,
+            1494,
+            1495,
+            1496,
+            1497,
+            1498,
+            1499,
+            1500,
+            1501,
+            1502,
+            1503,
+            1504,
+            1505,
+            1506,
+            1507,
+            1508,
+            1509,
+            1510,
+            1511,
+            1512,
+            1513,
+            1514,
+            1515,
+            1516,
+            1517,
+            1518,
+            1519,
+            1520,
+            1521,
+            1522,
+            1523,
+            1524,
+            1525,
+            1526,
+            1527,
+            1528,
+            1529,
+            1530,
+            1531,
+            1532,
+            1533,
+            1534,
+            1535,
+            1536,
+            1537,
+            1538,
+            1539,
+            1540,
+            1541,
+            1542,
+            1543,
+            1544,
+            1545,
+            1546,
+            1547,
+            1548,
+            1549,
+            1550,
+            1551,
+            1552,
+            1553,
+            1554,
+            1555,
+            1556,
+            1557,
+            1558,
+            1559,
+            1560,
+            1561,
+            1562,
+            1563,
+            1564,
+            1565,
+            1566,
+            1567,
+            1568,
+            1569,
+            1570,
+            1571,
+            1572,
+            1573,
+            1574,
+            1575,
+            1576,
+            1577,
+            1578
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            14,
+            26,
+            71,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 281
+},
+{
+    "fields": {
+        "pkgname": "eom",
+        "type_id": "eom.desktop",
+        "keywords": [
+            184,
+            193,
+            1579,
+            1580,
+            1581,
+            1582,
+            1583,
+            1584,
+            1585,
+            1586,
+            1587
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26,
+            71
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 282
+},
+{
+    "fields": {
+        "pkgname": "epiphany-askfedora.desktop",
+        "type_id": "epiphany-askfedora.desktop",
+        "keywords": [
+            1588,
+            1589,
+            1590
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "webapp",
+        "categories": [
+            4,
+            85
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 283
+},
+{
+    "fields": {
+        "pkgname": "epiphany-bbciplayer.desktop",
+        "type_id": "epiphany-bbciplayer.desktop",
+        "keywords": [
+            1591,
+            1592,
+            1593,
+            1594
+        ],
+        "project_license": null,
+        "type": "webapp",
+        "categories": [
+            65,
+            86
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 284
+},
+{
+    "fields": {
+        "pkgname": "epiphany-dropbox.desktop",
+        "type_id": "epiphany-dropbox.desktop",
+        "keywords": [
+            1595,
+            1596
+        ],
+        "project_license": null,
+        "type": "webapp",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 285
+},
+{
+    "fields": {
+        "pkgname": "epiphany-facebook.desktop",
+        "type_id": "epiphany-facebook.desktop",
+        "keywords": [
+            1121
+        ],
+        "project_license": null,
+        "type": "webapp",
+        "categories": [
+            23,
+            82
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 286
+},
+{
+    "fields": {
+        "pkgname": "epiphany-googledrive.desktop",
+        "type_id": "epiphany-googledrive.desktop",
+        "keywords": [
+            1597
+        ],
+        "project_license": null,
+        "type": "webapp",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 287
+},
+{
+    "fields": {
+        "pkgname": "epiphany-googlemaps.desktop",
+        "type_id": "epiphany-googlemaps.desktop",
+        "keywords": [
+            1598
+        ],
+        "project_license": null,
+        "type": "webapp",
+        "categories": [
+            21,
+            87
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 288
+},
+{
+    "fields": {
+        "pkgname": "epiphany-googleplus.desktop",
+        "type_id": "epiphany-googleplus.desktop",
+        "keywords": [
+            1599,
+            1600
+        ],
+        "project_license": null,
+        "type": "webapp",
+        "categories": [
+            23,
+            82
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 289
+},
+{
+    "fields": {
+        "pkgname": "epiphany-kindlecloud.desktop",
+        "type_id": "epiphany-kindlecloud.desktop",
+        "keywords": [
+            1601,
+            1602,
+            1603
+        ],
+        "project_license": null,
+        "type": "webapp",
+        "categories": [
+            19,
+            55
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 290
+},
+{
+    "fields": {
+        "pkgname": "epiphany-rdio.desktop",
+        "type_id": "epiphany-rdio.desktop",
+        "keywords": [
+            1092,
+            1604
+        ],
+        "project_license": null,
+        "type": "webapp",
+        "categories": [
+            6,
+            57
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 291
+},
+{
+    "fields": {
+        "pkgname": "epiphany-twitter.desktop",
+        "type_id": "epiphany-twitter.desktop",
+        "keywords": [
+            1605,
+            1606
+        ],
+        "project_license": null,
+        "type": "webapp",
+        "categories": [
+            23,
+            82
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 292
+},
+{
+    "fields": {
+        "pkgname": "epiphany",
+        "type_id": "epiphany.desktop",
+        "keywords": [
+            719,
+            1607,
+            1608,
+            1609,
+            1610,
+            1611,
+            1612,
+            1613,
+            1614,
+            1615,
+            1616,
+            1617,
+            1618,
+            1619,
+            1620,
+            1621,
+            1622,
+            1623,
+            1624,
+            1625,
+            1626,
+            1627,
+            1628,
+            1629,
+            1630,
+            1631,
+            1632,
+            1633,
+            1634,
+            1635,
+            1636,
+            1637,
+            1638,
+            1639,
+            1640,
+            1641,
+            1642,
+            1643,
+            1644,
+            1645,
+            1646,
+            1647,
+            1648,
+            1649,
+            1650,
+            1651,
+            1652,
+            1653,
+            1654,
+            1655,
+            1656,
+            1657,
+            1658,
+            1659,
+            1660,
+            1661,
+            1662,
+            1663,
+            1664,
+            1665,
+            1666,
+            1667,
+            1668,
+            1669,
+            1670,
+            1671,
+            1672,
+            1673,
+            1674,
+            1675,
+            1676,
+            1677,
+            1678,
+            1679,
+            1680,
+            1681,
+            1682,
+            1683,
+            1684,
+            1685,
+            1686,
+            1687,
+            1688,
+            1689,
+            1690,
+            1691,
+            1692,
+            1693,
+            1694,
+            1695,
+            1696,
+            1697,
+            1698,
+            1699,
+            1700,
+            1701,
+            1702,
+            1703,
+            1704,
+            1705,
+            1706,
+            1707,
+            1708,
+            1709,
+            1710,
+            1711,
+            1712,
+            1713,
+            1714,
+            1715,
+            1716,
+            1717,
+            1718,
+            1719,
+            1720,
+            1721,
+            1722,
+            1723,
+            1724,
+            1725,
+            1726,
+            1727,
+            1728,
+            1729,
+            1730
+        ],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            52
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 293
+},
+{
+    "fields": {
+        "pkgname": "aqsis",
+        "type_id": "eqsl.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            26,
+            61
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 294
+},
+{
+    "fields": {
+        "pkgname": "equalx",
+        "type_id": "equalx.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 295
+},
+{
+    "fields": {
+        "pkgname": "eric",
+        "type_id": "eric6.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 296
+},
+{
+    "fields": {
+        "pkgname": "eterm",
+        "type_id": "eterm.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            4,
+            5,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 297
+},
+{
+    "fields": {
+        "pkgname": "etherape",
+        "type_id": "etherape.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 298
+},
+{
+    "fields": {
+        "pkgname": "extremetuxracer",
+        "type_id": "etr.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 299
+},
+{
+    "fields": {
+        "pkgname": "ettercap",
+        "type_id": "ettercap.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 300
+},
+{
+    "fields": {
+        "pkgname": "evince-libs",
+        "type_id": "evince-comicsdocument",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-3.0+ AND LGPL-2.1+ AND MIT AND Afmparse",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 301
+},
+{
+    "fields": {
+        "pkgname": "evince-djvu",
+        "type_id": "evince-djvudocument",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-3.0+ AND LGPL-2.1+ AND MIT AND Afmparse",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 302
+},
+{
+    "fields": {
+        "pkgname": "evince-dvi",
+        "type_id": "evince-dvidocument",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-3.0+ AND LGPL-2.1+ AND MIT AND Afmparse",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 303
+},
+{
+    "fields": {
+        "pkgname": "evince-libs",
+        "type_id": "evince-pdfocument",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-3.0+ AND LGPL-2.1+ AND MIT AND Afmparse",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 304
+},
+{
+    "fields": {
+        "pkgname": "evince-libs",
+        "type_id": "evince-psdocument",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-3.0+ AND LGPL-2.1+ AND MIT AND Afmparse",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 305
+},
+{
+    "fields": {
+        "pkgname": "evince-libs",
+        "type_id": "evince-tiffdocument",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-3.0+ AND LGPL-2.1+ AND MIT AND Afmparse",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 306
+},
+{
+    "fields": {
+        "pkgname": "evince-libs",
+        "type_id": "evince-xpsdocument",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-3.0+ AND LGPL-2.1+ AND MIT AND Afmparse",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 307
+},
+{
+    "fields": {
+        "pkgname": "evince",
+        "type_id": "evince.desktop",
+        "keywords": [
+            186,
+            187,
+            188,
+            189,
+            191,
+            192,
+            194,
+            995,
+            1002,
+            1081,
+            1084,
+            1088,
+            1446,
+            1566,
+            1731,
+            1732,
+            1733,
+            1734,
+            1735,
+            1736,
+            1737,
+            1738,
+            1739,
+            1740,
+            1741,
+            1742,
+            1743,
+            1744,
+            1745,
+            1746,
+            1747,
+            1748,
+            1749,
+            1750,
+            1751,
+            1752,
+            1753,
+            1754,
+            1755,
+            1756,
+            1757,
+            1758,
+            1759,
+            1760,
+            1761,
+            1762,
+            1763,
+            1764,
+            1765,
+            1766,
+            1767,
+            1768,
+            1769,
+            1770,
+            1771,
+            1772,
+            1773,
+            1774,
+            1775,
+            1776,
+            1777,
+            1778,
+            1779,
+            1780,
+            1781,
+            1782,
+            1783,
+            1784,
+            1785,
+            1786,
+            1787,
+            1788,
+            1789,
+            1790,
+            1791,
+            1792,
+            1793,
+            1794,
+            1795,
+            1796,
+            1797,
+            1798,
+            1799,
+            1800,
+            1801,
+            1802,
+            1803,
+            1804,
+            1805,
+            1806,
+            1807,
+            1808,
+            1809,
+            1810,
+            1811,
+            1812,
+            1813,
+            1814,
+            1815,
+            1816,
+            1817,
+            1818,
+            1819,
+            1820,
+            1821,
+            1822,
+            1823,
+            1824,
+            1825,
+            1826,
+            1827,
+            1828,
+            1829,
+            1830,
+            1831,
+            1832,
+            1833,
+            1834,
+            1835,
+            1836,
+            1837,
+            1838,
+            1839,
+            1840,
+            1841,
+            1842,
+            1843,
+            1844,
+            1845,
+            1846,
+            1847,
+            1848,
+            1849,
+            1850,
+            1851,
+            1852,
+            1853,
+            1854,
+            1855,
+            1856,
+            1857,
+            1858,
+            1859,
+            1860,
+            1861,
+            1862,
+            1863,
+            1864,
+            1865,
+            1866,
+            1867,
+            1868,
+            1869,
+            1870,
+            1871,
+            1872,
+            1873
+        ],
+        "project_license": "GPL-2.0+ AND GPL-3.0+ AND LGPL-2.1+ AND MIT AND Afmparse",
+        "type": "desktop",
+        "categories": [
+            13,
+            14,
+            26,
+            84,
+            88
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 308
+},
+{
+    "fields": {
+        "pkgname": "evolution-bogofilter",
+        "type_id": "evolution-bogofilter",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 309
+},
+{
+    "fields": {
+        "pkgname": "evolution-ews",
+        "type_id": "evolution-ews",
+        "keywords": [],
+        "project_license": "LGPL-2.1",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 310
+},
+{
+    "fields": {
+        "pkgname": "evolution-mapi",
+        "type_id": "evolution-mapi",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 311
+},
+{
+    "fields": {
+        "pkgname": "evolution-rss",
+        "type_id": "evolution-rss",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 312
+},
+{
+    "fields": {
+        "pkgname": "evolution-spamassassin",
+        "type_id": "evolution-spamassassin",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 313
+},
+{
+    "fields": {
+        "pkgname": "evolution",
+        "type_id": "evolution.desktop",
+        "keywords": [
+            736,
+            794,
+            1283,
+            1874,
+            1875,
+            1876,
+            1877,
+            1878,
+            1879,
+            1880,
+            1881,
+            1882,
+            1883,
+            1884,
+            1885,
+            1886,
+            1887,
+            1888,
+            1889,
+            1890,
+            1891,
+            1892,
+            1893,
+            1894,
+            1895,
+            1896,
+            1897,
+            1898,
+            1899,
+            1900,
+            1901,
+            1902,
+            1903,
+            1904,
+            1905,
+            1906,
+            1907,
+            1908,
+            1909,
+            1910,
+            1911,
+            1912,
+            1913,
+            1914,
+            1915,
+            1916,
+            1917,
+            1918,
+            1919,
+            1920,
+            1921,
+            1922,
+            1923,
+            1924,
+            1925,
+            1926,
+            1927,
+            1928,
+            1929,
+            1930,
+            1931,
+            1932,
+            1933,
+            1934,
+            1935,
+            1936,
+            1937,
+            1938,
+            1939,
+            1940,
+            1941,
+            1942,
+            1943,
+            1944,
+            1945,
+            1946,
+            1947,
+            1948,
+            1949,
+            1950,
+            1951,
+            1952,
+            1953,
+            1954,
+            1955,
+            1956,
+            1957,
+            1958,
+            1959,
+            1960,
+            1961,
+            1962,
+            1963,
+            1964,
+            1965,
+            1966,
+            1967,
+            1968,
+            1969,
+            1970,
+            1971,
+            1972,
+            1973,
+            1974,
+            1975,
+            1976,
+            1977,
+            1978,
+            1979,
+            1980,
+            1981,
+            1982,
+            1983,
+            1984,
+            1985,
+            1986,
+            1987,
+            1988,
+            1989,
+            1990,
+            1991,
+            1992,
+            1993,
+            1994,
+            1995,
+            1996,
+            1997,
+            1998,
+            1999,
+            2000,
+            2001,
+            2002,
+            2003,
+            2004,
+            2005,
+            2006,
+            2007,
+            2008,
+            2009,
+            2010,
+            2011,
+            2012,
+            2013,
+            2014,
+            2015,
+            2016,
+            2017,
+            2018,
+            2019,
+            2020,
+            2021,
+            2022,
+            2023,
+            2024,
+            2025,
+            2026,
+            2027,
+            2028,
+            2029,
+            2030,
+            2031,
+            2032,
+            2033,
+            2034,
+            2035,
+            2036,
+            2037,
+            2038,
+            2039,
+            2040,
+            2041,
+            2042,
+            2043,
+            2044,
+            2045,
+            2046,
+            2047,
+            2048,
+            2049,
+            2050,
+            2051,
+            2052,
+            2053,
+            2054,
+            2055,
+            2056,
+            2057,
+            2058,
+            2059,
+            2060,
+            2061,
+            2062,
+            2063,
+            2064,
+            2065,
+            2066,
+            2067,
+            2068,
+            2069,
+            2070,
+            2071,
+            2072,
+            2073,
+            2074,
+            2075,
+            2076,
+            2077,
+            2078,
+            2079,
+            2080,
+            2081,
+            2082,
+            2083,
+            2084,
+            2085,
+            2086,
+            2087,
+            2088,
+            2089,
+            2090,
+            2091,
+            2092,
+            2093,
+            2094,
+            2095,
+            2096,
+            2097,
+            2098,
+            2099,
+            2100,
+            2101,
+            2102,
+            2103,
+            2104,
+            2105
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            13,
+            22,
+            67,
+            89
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 314
+},
+{
+    "fields": {
+        "pkgname": "exaile",
+        "type_id": "exaile.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 315
+},
+{
+    "fields": {
+        "pkgname": "exfalso",
+        "type_id": "exfalso.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 316
+},
+{
+    "fields": {
+        "pkgname": "expendable",
+        "type_id": "expendable.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            79
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 317
+},
+{
+    "fields": {
+        "pkgname": "kipi-plugins",
+        "type_id": "expoblending.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Adobe",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 318
+},
+{
+    "fields": {
+        "pkgname": "extrema",
+        "type_id": "extrema.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            21,
+            26,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 319
+},
+{
+    "fields": {
+        "pkgname": "eyesight",
+        "type_id": "eyesight.desktop",
+        "keywords": [
+            1368,
+            1369,
+            1370
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26,
+            71,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 320
+},
+{
+    "fields": {
+        "pkgname": "fbg2",
+        "type_id": "fbg2.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 321
+},
+{
+    "fields": {
+        "pkgname": "fbzx",
+        "type_id": "fbzx.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            29
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 322
+},
+{
+    "fields": {
+        "pkgname": "fcitx",
+        "type_id": "fcitx.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 323
+},
+{
+    "fields": {
+        "pkgname": "fedora-gooey-karma",
+        "type_id": "fedora-gooey-karma.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 324
+},
+{
+    "fields": {
+        "pkgname": "ffgtk",
+        "type_id": "ffgtk.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 325
+},
+{
+    "fields": {
+        "pkgname": "fgrun",
+        "type_id": "fgrun.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            15
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 326
+},
+{
+    "fields": {
+        "pkgname": "filezilla",
+        "type_id": "filezilla.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            76
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 327
+},
+{
+    "fields": {
+        "pkgname": "findthatword",
+        "type_id": "findthatword.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 328
+},
+{
+    "fields": {
+        "pkgname": "firefox",
+        "type_id": "firefox.desktop",
+        "keywords": [
+            719,
+            1607,
+            1608
+        ],
+        "project_license": "MPL-1.1 OR GPL-2.0+ OR LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            23,
+            52
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 329
+},
+{
+    "fields": {
+        "pkgname": "firewall-config",
+        "type_id": "firewall-config.desktop",
+        "keywords": [
+            2106,
+            2107,
+            2108,
+            2109,
+            2110,
+            2111,
+            2112,
+            2113,
+            2114,
+            2115,
+            2116,
+            2117,
+            2118,
+            2119,
+            2120,
+            2121,
+            2122,
+            2123,
+            2124,
+            2125,
+            2126,
+            2127,
+            2128,
+            2129,
+            2130,
+            2131,
+            2132,
+            2133,
+            2134,
+            2135,
+            2136,
+            2137,
+            2138,
+            2139,
+            2140,
+            2141,
+            2142,
+            2143,
+            2144,
+            2145,
+            2146,
+            2147,
+            2148,
+            2149,
+            2150,
+            2151,
+            2152,
+            2153,
+            2154,
+            2155,
+            2156,
+            2157,
+            2158
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            51,
+            68
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 330
+},
+{
+    "fields": {
+        "pkgname": "five-or-more",
+        "type_id": "five-or-more.desktop",
+        "keywords": [
+            198,
+            200,
+            2159,
+            2160,
+            2161,
+            2162,
+            2163,
+            2164,
+            2165,
+            2166,
+            2167,
+            2168,
+            2169,
+            2170,
+            2171,
+            2172,
+            2173,
+            2174,
+            2175,
+            2176,
+            2177,
+            2178,
+            2179,
+            2180,
+            2181,
+            2182,
+            2183,
+            2184,
+            2185,
+            2186,
+            2187,
+            2188,
+            2189,
+            2190,
+            2191,
+            2192,
+            2193,
+            2194,
+            2195,
+            2196,
+            2197,
+            2198,
+            2199,
+            2200,
+            2201,
+            2202,
+            2203,
+            2204,
+            2205,
+            2206,
+            2207,
+            2208,
+            2209,
+            2210,
+            2211,
+            2212,
+            2213,
+            2214,
+            2215,
+            2216,
+            2217,
+            2218,
+            2219,
+            2220,
+            2221,
+            2222,
+            2223,
+            2224,
+            2225,
+            2226,
+            2227,
+            2228,
+            2229,
+            2230,
+            2231,
+            2232,
+            2233,
+            2234,
+            2235,
+            2236,
+            2237,
+            2238,
+            2239,
+            2240,
+            2241,
+            2242,
+            2243,
+            2244,
+            2245,
+            2246,
+            2247,
+            2248,
+            2249,
+            2250,
+            2251,
+            2252,
+            2253,
+            2254,
+            2255,
+            2256,
+            2257,
+            2258,
+            2259,
+            2260,
+            2261,
+            2262,
+            2263,
+            2264,
+            2265,
+            2266,
+            2267,
+            2268,
+            2269,
+            2270,
+            2271,
+            2272,
+            2273,
+            2274,
+            2275,
+            2276,
+            2277,
+            2278,
+            2279,
+            2280,
+            2281,
+            2282,
+            2283,
+            2284,
+            2285,
+            2286,
+            2287,
+            2288,
+            2289,
+            2290,
+            2291,
+            2292,
+            2293,
+            2294,
+            2295,
+            2296,
+            2297,
+            2298,
+            2299,
+            2300,
+            2301,
+            2302,
+            2303,
+            2304
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 331
+},
+{
+    "fields": {
+        "pkgname": "flare",
+        "type_id": "flare.desktop",
+        "keywords": [],
+        "project_license": "CC-BY-SA-3.0 AND CC-BY-3.0 AND CC0-1.0 AND Public Domain",
+        "type": "desktop",
+        "categories": [
+            1,
+            74
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 332
+},
+{
+    "fields": {
+        "pkgname": "flash-plugin",
+        "type_id": "flash-player-properties.desktop",
+        "keywords": [],
+        "project_license": "Proprietary",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 333
+},
+{
+    "fields": {
+        "pkgname": "flaw",
+        "type_id": "flaw.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 334
+},
+{
+    "fields": {
+        "pkgname": "florence",
+        "type_id": "florence.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            5,
+            38
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 335
+},
+{
+    "fields": {
+        "pkgname": "calligra-flow",
+        "type_id": "flow.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 336
+},
+{
+    "fields": {
+        "pkgname": "fltk-fluid",
+        "type_id": "fluid.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            90
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 337
+},
+{
+    "fields": {
+        "pkgname": "flumotion",
+        "type_id": "flumotion-admin.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 338
+},
+{
+    "fields": {
+        "pkgname": "fmit",
+        "type_id": "fmit.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            91
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 339
+},
+{
+    "fields": {
+        "pkgname": "fmtools-tkradio",
+        "type_id": "fmtools.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 340
+},
+{
+    "fields": {
+        "pkgname": "focuswriter",
+        "type_id": "focuswriter.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            37
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 341
+},
+{
+    "fields": {
+        "pkgname": "font-manager",
+        "type_id": "font-manager.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26,
+            31
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 342
+},
+{
+    "fields": {
+        "pkgname": "fontforge",
+        "type_id": "fontforge.desktop",
+        "keywords": [
+            796,
+            2305,
+            2306,
+            2307,
+            2308,
+            2309
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 343
+},
+{
+    "fields": {
+        "pkgname": "fontmatrix",
+        "type_id": "fontmatrix.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            88
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 344
+},
+{
+    "fields": {
+        "pkgname": "fonts-tweak-tool",
+        "type_id": "fonts-tweak-tool.desktop",
+        "keywords": [],
+        "project_license": "LGPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 345
+},
+{
+    "fields": {
+        "pkgname": "fotoxx",
+        "type_id": "fotoxx.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 346
+},
+{
+    "fields": {
+        "pkgname": "four-in-a-row",
+        "type_id": "four-in-a-row.desktop",
+        "keywords": [
+            198,
+            200,
+            2159,
+            2163,
+            2164,
+            2165,
+            2166,
+            2167,
+            2168,
+            2169,
+            2170,
+            2171,
+            2172,
+            2173,
+            2174,
+            2175,
+            2176,
+            2177,
+            2178,
+            2179,
+            2180,
+            2181,
+            2182,
+            2183,
+            2184,
+            2185,
+            2186,
+            2187,
+            2188,
+            2189,
+            2190,
+            2191,
+            2192,
+            2193,
+            2194,
+            2195,
+            2196,
+            2197,
+            2198,
+            2199,
+            2200,
+            2201,
+            2202,
+            2203,
+            2204,
+            2205,
+            2206,
+            2207,
+            2208,
+            2209,
+            2210,
+            2211,
+            2212,
+            2213,
+            2214,
+            2215,
+            2216,
+            2217,
+            2218,
+            2219,
+            2220,
+            2221,
+            2222,
+            2223,
+            2224,
+            2225,
+            2226,
+            2227,
+            2228,
+            2229,
+            2230,
+            2231,
+            2232,
+            2233,
+            2234,
+            2235,
+            2236,
+            2237,
+            2238,
+            2239,
+            2240,
+            2241,
+            2242,
+            2243,
+            2244,
+            2248,
+            2249,
+            2250,
+            2251,
+            2252,
+            2253,
+            2254,
+            2255,
+            2256,
+            2257,
+            2258,
+            2259,
+            2260,
+            2261,
+            2262,
+            2263,
+            2264,
+            2265,
+            2266,
+            2267,
+            2268,
+            2269,
+            2270,
+            2271,
+            2272,
+            2273,
+            2275,
+            2276,
+            2277,
+            2278,
+            2279,
+            2280,
+            2281,
+            2282,
+            2283,
+            2284,
+            2285,
+            2286,
+            2287,
+            2288,
+            2289,
+            2293,
+            2294,
+            2295,
+            2296,
+            2297,
+            2298,
+            2299,
+            2300,
+            2301,
+            2302,
+            2303,
+            2304,
+            2310,
+            2311
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3 AND GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 347
+},
+{
+    "fields": {
+        "pkgname": "fourterm",
+        "type_id": "fourterm.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            5,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 348
+},
+{
+    "fields": {
+        "pkgname": "foxtrotgps",
+        "type_id": "foxtrotgps.desktop",
+        "keywords": [
+            2312,
+            2313,
+            2314,
+            2315,
+            2316,
+            2317,
+            2318,
+            2319,
+            2320,
+            2321,
+            2322,
+            2323,
+            2324,
+            2325,
+            2326,
+            2327,
+            2328,
+            2329,
+            2330,
+            2331,
+            2332,
+            2333,
+            2334,
+            2335,
+            2336,
+            2337,
+            2338,
+            2339,
+            2340,
+            2341,
+            2342,
+            2343,
+            2344
+        ],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            5,
+            25
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 349
+},
+{
+    "fields": {
+        "pkgname": "frama-c",
+        "type_id": "frama-c-gui.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1 AND GPL-2.0 AND GPL-2.0+ AND BSD-3-Clause AND (QPL-1.0)",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 350
+},
+{
+    "fields": {
+        "pkgname": "freecad",
+        "type_id": "freecad.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            26,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 351
+},
+{
+    "fields": {
+        "pkgname": "freeciv",
+        "type_id": "freeciv-gtk2.desktop",
+        "keywords": [
+            2159,
+            2345,
+            2346,
+            2347,
+            2348,
+            2349,
+            2350
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 352
+},
+{
+    "fields": {
+        "pkgname": "freeciv",
+        "type_id": "freeciv-mp-gtk2.desktop",
+        "keywords": [
+            2159,
+            2345,
+            2346,
+            2347,
+            2348,
+            2349,
+            2350,
+            2351,
+            2352
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 353
+},
+{
+    "fields": {
+        "pkgname": "freecol-imperator-fonts",
+        "type_id": "freecol-imperator",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 354
+},
+{
+    "fields": {
+        "pkgname": "freecol",
+        "type_id": "freecol.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 355
+},
+{
+    "fields": {
+        "pkgname": "freediams",
+        "type_id": "freediams.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            39
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 356
+},
+{
+    "fields": {
+        "pkgname": "freedoom",
+        "type_id": "freedoom.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 357
+},
+{
+    "fields": {
+        "pkgname": "freemedforms-emr",
+        "type_id": "freemedforms.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            39
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 358
+},
+{
+    "fields": {
+        "pkgname": "freemind",
+        "type_id": "freemind.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND MIT",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 359
+},
+{
+    "fields": {
+        "pkgname": "frescobaldi",
+        "type_id": "frescobaldi.desktop",
+        "keywords": [
+            796,
+            2353,
+            2354
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            5,
+            7,
+            32,
+            57
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 360
+},
+{
+    "fields": {
+        "pkgname": "fritzing",
+        "type_id": "fritzing.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            16
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 361
+},
+{
+    "fields": {
+        "pkgname": "frogr",
+        "type_id": "frogr.desktop",
+        "keywords": [
+            444,
+            455,
+            457,
+            538,
+            543,
+            548,
+            584,
+            878,
+            1366,
+            1369,
+            1395,
+            1396,
+            1408,
+            1414,
+            1440,
+            1455,
+            1466,
+            1467,
+            1505,
+            1506,
+            1528,
+            1531,
+            1570,
+            1571,
+            2355,
+            2356,
+            2357,
+            2358,
+            2359,
+            2360,
+            2361,
+            2362,
+            2363,
+            2364,
+            2365,
+            2366,
+            2367,
+            2368,
+            2369,
+            2370,
+            2371,
+            2372,
+            2373,
+            2374,
+            2375,
+            2376,
+            2377,
+            2378,
+            2379,
+            2380,
+            2381,
+            2382,
+            2383,
+            2384,
+            2385,
+            2386,
+            2387,
+            2388,
+            2389,
+            2390,
+            2391,
+            2392,
+            2393,
+            2394,
+            2395,
+            2396,
+            2397,
+            2398,
+            2399,
+            2400,
+            2401,
+            2402,
+            2403,
+            2404,
+            2405,
+            2406,
+            2407,
+            2408,
+            2409,
+            2410,
+            2411,
+            2412
+        ],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 362
+},
+{
+    "fields": {
+        "pkgname": "frozen-bubble",
+        "type_id": "frozen-bubble.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 363
+},
+{
+    "fields": {
+        "pkgname": "fuelmanager",
+        "type_id": "fuelmanager.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 364
+},
+{
+    "fields": {
+        "pkgname": "funguloids",
+        "type_id": "funguloids.desktop",
+        "keywords": [],
+        "project_license": "Zlib",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 365
+},
+{
+    "fields": {
+        "pkgname": "fvkbd",
+        "type_id": "fvkbd-gtk.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 366
+},
+{
+    "fields": {
+        "pkgname": "fwbackups",
+        "type_id": "fwbackups.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 367
+},
+{
+    "fields": {
+        "pkgname": "gajim",
+        "type_id": "gajim.desktop",
+        "keywords": [
+            1120,
+            1123,
+            1125,
+            1128,
+            1204,
+            1205,
+            2413,
+            2414,
+            2415,
+            2416,
+            2417,
+            2418,
+            2419
+        ],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            82
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 368
+},
+{
+    "fields": {
+        "pkgname": "galculator",
+        "type_id": "galculator.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            92
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 369
+},
+{
+    "fields": {
+        "pkgname": "gambas3-runtime",
+        "type_id": "gambas3.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 370
+},
+{
+    "fields": {
+        "pkgname": "ganyremote",
+        "type_id": "ganyremote.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 371
+},
+{
+    "fields": {
+        "pkgname": "garden",
+        "type_id": "garden.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 372
+},
+{
+    "fields": {
+        "pkgname": "gargi-fonts",
+        "type_id": "gargi",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 373
+},
+{
+    "fields": {
+        "pkgname": "gaupol",
+        "type_id": "gaupol.desktop",
+        "keywords": [
+            344,
+            403,
+            2420,
+            2421,
+            2422,
+            2423,
+            2424,
+            2425
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            7,
+            56,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 374
+},
+{
+    "fields": {
+        "pkgname": "gausssum",
+        "type_id": "gausssum.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            18,
+            20,
+            21,
+            28
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 375
+},
+{
+    "fields": {
+        "pkgname": "gazebo",
+        "type_id": "gazebo.desktop",
+        "keywords": [],
+        "project_license": "Apache-2.0 AND BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            93
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 376
+},
+{
+    "fields": {
+        "pkgname": "gbrainy",
+        "type_id": "gbrainy.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 377
+},
+{
+    "fields": {
+        "pkgname": "gchem3d",
+        "type_id": "gchem3d.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            18,
+            19,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 378
+},
+{
+    "fields": {
+        "pkgname": "gchemcalc",
+        "type_id": "gchemcalc.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            18,
+            19,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 379
+},
+{
+    "fields": {
+        "pkgname": "gchempaint",
+        "type_id": "gchempaint.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            18,
+            19,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 380
+},
+{
+    "fields": {
+        "pkgname": "gchemtable",
+        "type_id": "gchemtable.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            18,
+            19,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 381
+},
+{
+    "fields": {
+        "pkgname": "gnome-color-manager",
+        "type_id": "gcm-viewer.desktop",
+        "keywords": [
+            2426,
+            2427,
+            2428,
+            2429,
+            2430,
+            2431,
+            2432,
+            2433,
+            2434,
+            2435,
+            2436,
+            2437,
+            2438,
+            2439,
+            2440,
+            2441,
+            2442,
+            2443,
+            2444,
+            2445,
+            2446,
+            2447,
+            2448,
+            2449,
+            2450,
+            2451,
+            2452,
+            2453,
+            2454,
+            2455,
+            2456,
+            2457,
+            2458,
+            2459,
+            2460
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 382
+},
+{
+    "fields": {
+        "pkgname": "gcompris",
+        "type_id": "gcompris.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            19
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 383
+},
+{
+    "fields": {
+        "pkgname": "gconf-editor",
+        "type_id": "gconf-editor.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 384
+},
+{
+    "fields": {
+        "pkgname": "gcrystal",
+        "type_id": "gcrystal.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            18,
+            19,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 385
+},
+{
+    "fields": {
+        "pkgname": "gcstar",
+        "type_id": "gcstar.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 386
+},
+{
+    "fields": {
+        "pkgname": "libgda-tools",
+        "type_id": "gda-browser-5.0.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            11,
+            40
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 387
+},
+{
+    "fields": {
+        "pkgname": "gdouros-aegean-fonts",
+        "type_id": "gdouros-aegean",
+        "keywords": [],
+        "project_license": "Public Domain",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 388
+},
+{
+    "fields": {
+        "pkgname": "gdouros-aegyptus-fonts",
+        "type_id": "gdouros-aegyptus",
+        "keywords": [],
+        "project_license": "Public Domain",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 389
+},
+{
+    "fields": {
+        "pkgname": "gdouros-symbola-fonts",
+        "type_id": "gdouros-symbola",
+        "keywords": [],
+        "project_license": "Public Domain",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 390
+},
+{
+    "fields": {
+        "pkgname": "geany",
+        "type_id": "geany.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 391
+},
+{
+    "fields": {
+        "pkgname": "geary",
+        "type_id": "geary.desktop",
+        "keywords": [
+            1182,
+            1901,
+            1904,
+            1915,
+            1919,
+            1926,
+            1933,
+            2050,
+            2064,
+            2069,
+            2096,
+            2105,
+            2461,
+            2462,
+            2463,
+            2464,
+            2465,
+            2466,
+            2467,
+            2468,
+            2469,
+            2470,
+            2471,
+            2472,
+            2473,
+            2474,
+            2475,
+            2476,
+            2477,
+            2478,
+            2479,
+            2480,
+            2481,
+            2482,
+            2483,
+            2484,
+            2485,
+            2486,
+            2487,
+            2488,
+            2489,
+            2490,
+            2491,
+            2492,
+            2493,
+            2494,
+            2495,
+            2496,
+            2497,
+            2498,
+            2499,
+            2500,
+            2501,
+            2502,
+            2503,
+            2504,
+            2505,
+            2506,
+            2507,
+            2508,
+            2509,
+            2510,
+            2511,
+            2512,
+            2513,
+            2514,
+            2515,
+            2516,
+            2517,
+            2518,
+            2519,
+            2520,
+            2521,
+            2522,
+            2523,
+            2524,
+            2525,
+            2526,
+            2527,
+            2528,
+            2529,
+            2530,
+            2531,
+            2532,
+            2533,
+            2534,
+            2535,
+            2536,
+            2537,
+            2538,
+            2539,
+            2540,
+            2541
+        ],
+        "project_license": "LGPL-2.1+ AND BSD-3-Clause AND CC-BY-3.0 AND CC-BY-SA-3.0 AND Public Domain",
+        "type": "desktop",
+        "categories": [
+            22,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 392
+},
+{
+    "fields": {
+        "pkgname": "geda-gattrib",
+        "type_id": "geda-gattrib.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            16,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 393
+},
+{
+    "fields": {
+        "pkgname": "geda-gschem",
+        "type_id": "geda-gschem.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            16,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 394
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-bookmarks",
+        "type_id": "gedit-bookmarks",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 395
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-bracketcompletion",
+        "type_id": "gedit-bracketcompletion",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 396
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-charmap",
+        "type_id": "gedit-charmap",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 397
+},
+{
+    "fields": {
+        "pkgname": "gedit-code-assistance",
+        "type_id": "gedit-code-assistance",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 398
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-codecomment",
+        "type_id": "gedit-codecomment",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 399
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-colorpicker",
+        "type_id": "gedit-colorpicker",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 400
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-colorschemer",
+        "type_id": "gedit-colorschemer",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 401
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-commander",
+        "type_id": "gedit-commander",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 402
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-dashboard",
+        "type_id": "gedit-dashboard",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 403
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-drawspaces",
+        "type_id": "gedit-drawspaces",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 404
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-git",
+        "type_id": "gedit-git",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 405
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-joinlines",
+        "type_id": "gedit-joinlines",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 406
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-multiedit",
+        "type_id": "gedit-multiedit",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 407
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-smartspaces",
+        "type_id": "gedit-smartspaces",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 408
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-synctex",
+        "type_id": "gedit-synctex",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 409
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-terminal",
+        "type_id": "gedit-terminal",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 410
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-textsize",
+        "type_id": "gedit-textsize",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 411
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-wordcompletion",
+        "type_id": "gedit-wordcompletion",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 412
+},
+{
+    "fields": {
+        "pkgname": "gedit-plugin-zeitgeist",
+        "type_id": "gedit-zeitgeist",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 413
+},
+{
+    "fields": {
+        "pkgname": "geeqie",
+        "type_id": "geeqie.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 414
+},
+{
+    "fields": {
+        "pkgname": "mono-tools-gendarme",
+        "type_id": "gendarme-wizard.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            11,
+            66
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 415
+},
+{
+    "fields": {
+        "pkgname": "gentoo",
+        "type_id": "gentoo.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            3,
+            4,
+            33
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 416
+},
+{
+    "fields": {
+        "pkgname": "geomorph",
+        "type_id": "geomorph.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            26,
+            61
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 417
+},
+{
+    "fields": {
+        "pkgname": "gerbv",
+        "type_id": "gerbv.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            16,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 418
+},
+{
+    "fields": {
+        "pkgname": "kicad",
+        "type_id": "gerbview.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            16
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 419
+},
+{
+    "fields": {
+        "pkgname": "gfs-ambrosia-fonts",
+        "type_id": "gfs-ambrosia",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 420
+},
+{
+    "fields": {
+        "pkgname": "gfs-artemisia-fonts",
+        "type_id": "gfs-artemisia",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 421
+},
+{
+    "fields": {
+        "pkgname": "gfs-baskerville-fonts",
+        "type_id": "gfs-baskerville",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 422
+},
+{
+    "fields": {
+        "pkgname": "gfs-bodoni-fonts",
+        "type_id": "gfs-bodoni",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 423
+},
+{
+    "fields": {
+        "pkgname": "gfs-bodoni-classic-fonts",
+        "type_id": "gfs-bodoni-classic",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 424
+},
+{
+    "fields": {
+        "pkgname": "gfs-complutum-fonts",
+        "type_id": "gfs-complutum",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 425
+},
+{
+    "fields": {
+        "pkgname": "gfs-decker-fonts",
+        "type_id": "gfs-decker",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 426
+},
+{
+    "fields": {
+        "pkgname": "gfs-didot-fonts",
+        "type_id": "gfs-didot",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 427
+},
+{
+    "fields": {
+        "pkgname": "gfs-didot-classic-fonts",
+        "type_id": "gfs-didot-classic",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 428
+},
+{
+    "fields": {
+        "pkgname": "gfs-eustace-fonts",
+        "type_id": "gfs-eustace",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 429
+},
+{
+    "fields": {
+        "pkgname": "gfs-fleischman-fonts",
+        "type_id": "gfs-fleischman",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 430
+},
+{
+    "fields": {
+        "pkgname": "gfs-garaldus-fonts",
+        "type_id": "gfs-garaldus",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 431
+},
+{
+    "fields": {
+        "pkgname": "gfs-gazis-fonts",
+        "type_id": "gfs-gazis",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 432
+},
+{
+    "fields": {
+        "pkgname": "gfs-goschen-fonts",
+        "type_id": "gfs-goschen",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 433
+},
+{
+    "fields": {
+        "pkgname": "gfs-ignacio-fonts",
+        "type_id": "gfs-ignacio",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 434
+},
+{
+    "fields": {
+        "pkgname": "gfs-jackson-fonts",
+        "type_id": "gfs-jackson",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 435
+},
+{
+    "fields": {
+        "pkgname": "gfs-neohellenic-fonts",
+        "type_id": "gfs-neohellenic",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 436
+},
+{
+    "fields": {
+        "pkgname": "gfs-nicefore-fonts",
+        "type_id": "gfs-nicefore",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 437
+},
+{
+    "fields": {
+        "pkgname": "gfs-olga-fonts",
+        "type_id": "gfs-olga",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 438
+},
+{
+    "fields": {
+        "pkgname": "gfs-philostratos-fonts",
+        "type_id": "gfs-philostratos",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 439
+},
+{
+    "fields": {
+        "pkgname": "gfs-theokritos-fonts",
+        "type_id": "gfs-theokritos",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 440
+},
+{
+    "fields": {
+        "pkgname": "ghex",
+        "type_id": "ghex.desktop",
+        "keywords": [
+            842,
+            844,
+            845,
+            848,
+            849,
+            852,
+            853,
+            854,
+            859,
+            860,
+            866,
+            874,
+            2542,
+            2543,
+            2544,
+            2545,
+            2546,
+            2547,
+            2548,
+            2549,
+            2550,
+            2551,
+            2552,
+            2553,
+            2554,
+            2555,
+            2556,
+            2557,
+            2558,
+            2559,
+            2560,
+            2561,
+            2562,
+            2563,
+            2564,
+            2565,
+            2566,
+            2567,
+            2568,
+            2569,
+            2570,
+            2571,
+            2572,
+            2573,
+            2574,
+            2575
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 441
+},
+{
+    "fields": {
+        "pkgname": "giggle",
+        "type_id": "giggle.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            94
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 442
+},
+{
+    "fields": {
+        "pkgname": "gimagereader-gtk",
+        "type_id": "gimagereader-gtk.desktop",
+        "keywords": [
+            2576,
+            2577,
+            2578,
+            2579
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            35
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 443
+},
+{
+    "fields": {
+        "pkgname": "gimagereader-qt",
+        "type_id": "gimagereader-qt5.desktop",
+        "keywords": [
+            2576,
+            2577,
+            2578,
+            2579
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            35
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 444
+},
+{
+    "fields": {
+        "pkgname": "gimmix",
+        "type_id": "gimmix.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 445
+},
+{
+    "fields": {
+        "pkgname": "gimp-high-pass-filter",
+        "type_id": "gimp-high-pass-filter",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 446
+},
+{
+    "fields": {
+        "pkgname": "gimp-paint-studio",
+        "type_id": "gimp-paint-studio",
+        "keywords": [],
+        "project_license": "CC-BY-SA-3.0 AND GPL-2.0",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 447
+},
+{
+    "fields": {
+        "pkgname": "gimp",
+        "type_id": "gimp.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            26,
+            71,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 448
+},
+{
+    "fields": {
+        "pkgname": "gipfel",
+        "type_id": "gipfel.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 449
+},
+{
+    "fields": {
+        "pkgname": "git-cola",
+        "type_id": "git-cola.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            94
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 450
+},
+{
+    "fields": {
+        "pkgname": "gitg",
+        "type_id": "gitg.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 451
+},
+{
+    "fields": {
+        "pkgname": "gitso",
+        "type_id": "gitso.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            95
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 452
+},
+{
+    "fields": {
+        "pkgname": "gjots2",
+        "type_id": "gjots2.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 453
+},
+{
+    "fields": {
+        "pkgname": "glabels",
+        "type_id": "glabels-3.0.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 454
+},
+{
+    "fields": {
+        "pkgname": "glade3",
+        "type_id": "glade-3.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            90
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 455
+},
+{
+    "fields": {
+        "pkgname": "glade",
+        "type_id": "glade.desktop",
+        "keywords": [
+            2580,
+            2581,
+            2582,
+            2583,
+            2584,
+            2585,
+            2586,
+            2587,
+            2588,
+            2589,
+            2590,
+            2591,
+            2592,
+            2593,
+            2594,
+            2595,
+            2596,
+            2597,
+            2598,
+            2599,
+            2600,
+            2601,
+            2602,
+            2603,
+            2604,
+            2605,
+            2606,
+            2607,
+            2608,
+            2609,
+            2610,
+            2611,
+            2612,
+            2613,
+            2614,
+            2615,
+            2616,
+            2617,
+            2618,
+            2619,
+            2620,
+            2621,
+            2622,
+            2623,
+            2624,
+            2625,
+            2626,
+            2627,
+            2628,
+            2629,
+            2630,
+            2631,
+            2632,
+            2633,
+            2634,
+            2635,
+            2636,
+            2637,
+            2638,
+            2639,
+            2640,
+            2641,
+            2642,
+            2643,
+            2644,
+            2645,
+            2646,
+            2647,
+            2648,
+            2649,
+            2650,
+            2651,
+            2652,
+            2653,
+            2654,
+            2655,
+            2656,
+            2657,
+            2658,
+            2659,
+            2660,
+            2661,
+            2662,
+            2663,
+            2664,
+            2665,
+            2666,
+            2667,
+            2668,
+            2669,
+            2670,
+            2671,
+            2672,
+            2673,
+            2674,
+            2675,
+            2676,
+            2677
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            11,
+            90
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 456
+},
+{
+    "fields": {
+        "pkgname": "GLC_Player",
+        "type_id": "glc_player.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 457
+},
+{
+    "fields": {
+        "pkgname": "glmark2",
+        "type_id": "glmark2-drm.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 458
+},
+{
+    "fields": {
+        "pkgname": "glmark2",
+        "type_id": "glmark2-es2-drm.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 459
+},
+{
+    "fields": {
+        "pkgname": "glmark2",
+        "type_id": "glmark2-es2.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 460
+},
+{
+    "fields": {
+        "pkgname": "glmark2",
+        "type_id": "glmark2.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 461
+},
+{
+    "fields": {
+        "pkgname": "glob2",
+        "type_id": "glob2.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 462
+},
+{
+    "fields": {
+        "pkgname": "glogg",
+        "type_id": "glogg.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            11,
+            47
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 463
+},
+{
+    "fields": {
+        "pkgname": "glom",
+        "type_id": "glom.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            40
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 464
+},
+{
+    "fields": {
+        "pkgname": "gmpc",
+        "type_id": "gmpc.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 465
+},
+{
+    "fields": {
+        "pkgname": "gmsh-common",
+        "type_id": "gmsh.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            21,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 466
+},
+{
+    "fields": {
+        "pkgname": "gnaural",
+        "type_id": "gnaural.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7,
+            56
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 467
+},
+{
+    "fields": {
+        "pkgname": "gnomad2",
+        "type_id": "gnomad2.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 468
+},
+{
+    "fields": {
+        "pkgname": "gnome-2048",
+        "type_id": "gnome-2048.desktop",
+        "keywords": [
+            2678,
+            2679,
+            2680,
+            2681,
+            2682,
+            2683,
+            2684
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 469
+},
+{
+    "fields": {
+        "pkgname": "gnome-abrt",
+        "type_id": "gnome-abrt.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 470
+},
+{
+    "fields": {
+        "pkgname": "gnome-activity-journal",
+        "type_id": "gnome-activity-journal.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 471
+},
+{
+    "fields": {
+        "pkgname": "gnome-calculator",
+        "type_id": "gnome-calculator.desktop",
+        "keywords": [
+            1866,
+            1869,
+            2685,
+            2686,
+            2687,
+            2688,
+            2689,
+            2690,
+            2691,
+            2692,
+            2693,
+            2694,
+            2695,
+            2696,
+            2697,
+            2698,
+            2699,
+            2700,
+            2701,
+            2702,
+            2703,
+            2704,
+            2705,
+            2706,
+            2707,
+            2708,
+            2709,
+            2710,
+            2711,
+            2712,
+            2713,
+            2714,
+            2715,
+            2716,
+            2717,
+            2718,
+            2719,
+            2720,
+            2721,
+            2722,
+            2723,
+            2724,
+            2725,
+            2726,
+            2727,
+            2728,
+            2729,
+            2730,
+            2731,
+            2732,
+            2733,
+            2734,
+            2735,
+            2736,
+            2737,
+            2738,
+            2739,
+            2740,
+            2741,
+            2742,
+            2743,
+            2744,
+            2745,
+            2746,
+            2747,
+            2748,
+            2749,
+            2750,
+            2751,
+            2752,
+            2753,
+            2754,
+            2755,
+            2756,
+            2757,
+            2758,
+            2759,
+            2760,
+            2761,
+            2762,
+            2763,
+            2764,
+            2765,
+            2766,
+            2767,
+            2768,
+            2769,
+            2770,
+            2771,
+            2772,
+            2773,
+            2774,
+            2775,
+            2776,
+            2777,
+            2778,
+            2779,
+            2780,
+            2781,
+            2782,
+            2783,
+            2784,
+            2785,
+            2786,
+            2787,
+            2788,
+            2789,
+            2790,
+            2791,
+            2792,
+            2793,
+            2794,
+            2795,
+            2796,
+            2797,
+            2798,
+            2799,
+            2800,
+            2801,
+            2802,
+            2803,
+            2804,
+            2805,
+            2806,
+            2807,
+            2808,
+            2809,
+            2810,
+            2811,
+            2812,
+            2813,
+            2814,
+            2815,
+            2816,
+            2817,
+            2818,
+            2819,
+            2820,
+            2821,
+            2822,
+            2823,
+            2824,
+            2825,
+            2826,
+            2827,
+            2828,
+            2829,
+            2830,
+            2831,
+            2832,
+            2833,
+            2834,
+            2835,
+            2836,
+            2837,
+            2838,
+            2839,
+            2840,
+            2841,
+            2842,
+            2843,
+            2844,
+            2845,
+            2846,
+            2847,
+            2848,
+            2849,
+            2850,
+            2851,
+            2852,
+            2853,
+            2854,
+            2855,
+            2856,
+            2857,
+            2858,
+            2859,
+            2860,
+            2861,
+            2862,
+            2863,
+            2864,
+            2865,
+            2866,
+            2867,
+            2868,
+            2869,
+            2870,
+            2871,
+            2872,
+            2873,
+            2874,
+            2875,
+            2876,
+            2877,
+            2878,
+            2879,
+            2880,
+            2881,
+            2882,
+            2883,
+            2884,
+            2885,
+            2886,
+            2887,
+            2888,
+            2889,
+            2890,
+            2891,
+            2892,
+            2893,
+            2894,
+            2895,
+            2896,
+            2897,
+            2898,
+            2899,
+            2900,
+            2901,
+            2902,
+            2903,
+            2904,
+            2905,
+            2906,
+            2907,
+            2908,
+            2909,
+            2910,
+            2911,
+            2912,
+            2913,
+            2914,
+            2915,
+            2916,
+            2917,
+            2918,
+            2919,
+            2920,
+            2921,
+            2922,
+            2923,
+            2924,
+            2925,
+            2926,
+            2927,
+            2928,
+            2929,
+            2930,
+            2931,
+            2932,
+            2933,
+            2934,
+            2935,
+            2936,
+            2937,
+            2938,
+            2939,
+            2940,
+            2941,
+            2942,
+            2943,
+            2944,
+            2945,
+            2946
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            92
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 472
+},
+{
+    "fields": {
+        "pkgname": "gnome-chess",
+        "type_id": "gnome-chess.desktop",
+        "keywords": [
+            198,
+            2159,
+            2163,
+            2166,
+            2167,
+            2169,
+            2170,
+            2171,
+            2173,
+            2174,
+            2176,
+            2178,
+            2180,
+            2181,
+            2183,
+            2184,
+            2186,
+            2187,
+            2188,
+            2189,
+            2192,
+            2193,
+            2194,
+            2195,
+            2197,
+            2198,
+            2201,
+            2202,
+            2203,
+            2205,
+            2206,
+            2208,
+            2209,
+            2212,
+            2213,
+            2215,
+            2217,
+            2218,
+            2219,
+            2220,
+            2222,
+            2224,
+            2229,
+            2232,
+            2234,
+            2235,
+            2237,
+            2238,
+            2239,
+            2240,
+            2243,
+            2244,
+            2248,
+            2252,
+            2253,
+            2256,
+            2257,
+            2258,
+            2259,
+            2261,
+            2262,
+            2264,
+            2266,
+            2267,
+            2270,
+            2271,
+            2272,
+            2275,
+            2277,
+            2278,
+            2280,
+            2282,
+            2283,
+            2285,
+            2286,
+            2288,
+            2289,
+            2290,
+            2293,
+            2295,
+            2296,
+            2297,
+            2299,
+            2300,
+            2302,
+            2303,
+            2311,
+            2947,
+            2948,
+            2949,
+            2950,
+            2951,
+            2952,
+            2953,
+            2954,
+            2955,
+            2956,
+            2957,
+            2958,
+            2959,
+            2960,
+            2961,
+            2962
+        ],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            60
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 473
+},
+{
+    "fields": {
+        "pkgname": "gnome-commander",
+        "type_id": "gnome-commander.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            3,
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 474
+},
+{
+    "fields": {
+        "pkgname": "control-center",
+        "type_id": "gnome-control-center.desktop",
+        "keywords": [
+            610,
+            615,
+            619,
+            628,
+            635,
+            639,
+            646,
+            652,
+            655,
+            664,
+            685,
+            686,
+            688,
+            689,
+            697,
+            700,
+            704,
+            708,
+            709,
+            710,
+            711,
+            713,
+            716,
+            718,
+            2963,
+            2964,
+            2965,
+            2966,
+            2967,
+            2968,
+            2969,
+            2970,
+            2971,
+            2972,
+            2973,
+            2974,
+            2975,
+            2976,
+            2977,
+            2978,
+            2979,
+            2980,
+            2981,
+            2982,
+            2983,
+            2984,
+            2985,
+            2986,
+            2987,
+            2988,
+            2989,
+            2990,
+            2991,
+            2992,
+            2993,
+            2994,
+            2995,
+            2996,
+            2997,
+            2998,
+            2999,
+            3000,
+            3001,
+            3002,
+            3003,
+            3004,
+            3005,
+            3006,
+            3007,
+            3008,
+            3009,
+            3010,
+            3011,
+            3012,
+            3013,
+            3014,
+            3015,
+            3016,
+            3017,
+            3018,
+            3019,
+            3020,
+            3021,
+            3022,
+            3023,
+            3024,
+            3025,
+            3026,
+            3027,
+            3028,
+            3029,
+            3030,
+            3031,
+            3032,
+            3033,
+            3034,
+            3035,
+            3036,
+            3037,
+            3038,
+            3039,
+            3040,
+            3041,
+            3042,
+            3043,
+            3044,
+            3045,
+            3046,
+            3047,
+            3048,
+            3049,
+            3050,
+            3051,
+            3052,
+            3053,
+            3054,
+            3055,
+            3056,
+            3057,
+            3058,
+            3059,
+            3060,
+            3061,
+            3062,
+            3063,
+            3064,
+            3065,
+            3066,
+            3067,
+            3068,
+            3069,
+            3070,
+            3071,
+            3072,
+            3073,
+            3074,
+            3075,
+            3076,
+            3077,
+            3078,
+            3079,
+            3080,
+            3081,
+            3082,
+            3083,
+            3084,
+            3085,
+            3086,
+            3087,
+            3088,
+            3089,
+            3090,
+            3091,
+            3092,
+            3093,
+            3094,
+            3095,
+            3096,
+            3097,
+            3098,
+            3099,
+            3100,
+            3101,
+            3102
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 475
+},
+{
+    "fields": {
+        "pkgname": "gnome-disk-utility",
+        "type_id": "gnome-disks.desktop",
+        "keywords": [
+            98,
+            121,
+            341,
+            342,
+            343,
+            362,
+            378,
+            392,
+            398,
+            400,
+            412,
+            415,
+            417,
+            426,
+            431,
+            437,
+            441,
+            443,
+            452,
+            463,
+            467,
+            469,
+            474,
+            478,
+            489,
+            496,
+            498,
+            499,
+            503,
+            506,
+            507,
+            510,
+            515,
+            525,
+            533,
+            539,
+            540,
+            544,
+            545,
+            555,
+            556,
+            557,
+            561,
+            569,
+            574,
+            577,
+            582,
+            583,
+            586,
+            590,
+            1447,
+            1479,
+            1528,
+            1531,
+            1584,
+            1597,
+            3092,
+            3093,
+            3103,
+            3104,
+            3105,
+            3106,
+            3107,
+            3108,
+            3109,
+            3110,
+            3111,
+            3112,
+            3113,
+            3114,
+            3115,
+            3116,
+            3117,
+            3118,
+            3119,
+            3120,
+            3121,
+            3122,
+            3123,
+            3124,
+            3125,
+            3126,
+            3127,
+            3128,
+            3129,
+            3130,
+            3131,
+            3132,
+            3133,
+            3134,
+            3135,
+            3136,
+            3137,
+            3138,
+            3139,
+            3140,
+            3141,
+            3142,
+            3143,
+            3144,
+            3145,
+            3146,
+            3147,
+            3148,
+            3149,
+            3150,
+            3151,
+            3152,
+            3153,
+            3154,
+            3155,
+            3156,
+            3157,
+            3158,
+            3159,
+            3160,
+            3161,
+            3162,
+            3163,
+            3164,
+            3165,
+            3166,
+            3167,
+            3168,
+            3169,
+            3170,
+            3171,
+            3172,
+            3173,
+            3174,
+            3175,
+            3176,
+            3177,
+            3178,
+            3179,
+            3180,
+            3181,
+            3182,
+            3183,
+            3184,
+            3185,
+            3186,
+            3187,
+            3188,
+            3189,
+            3190,
+            3191,
+            3192,
+            3193,
+            3194,
+            3195,
+            3196,
+            3197,
+            3198,
+            3199,
+            3200,
+            3201,
+            3202,
+            3203,
+            3204,
+            3205,
+            3206,
+            3207,
+            3208,
+            3209,
+            3210,
+            3211,
+            3212,
+            3213,
+            3214,
+            3215,
+            3216,
+            3217,
+            3218,
+            3219,
+            3220,
+            3221,
+            3222,
+            3223,
+            3224,
+            3225,
+            3226,
+            3227,
+            3228,
+            3229,
+            3230,
+            3231,
+            3232,
+            3233,
+            3234,
+            3235,
+            3236,
+            3237,
+            3238,
+            3239,
+            3240,
+            3241,
+            3242,
+            3243,
+            3244,
+            3245,
+            3246,
+            3247,
+            3248,
+            3249,
+            3250,
+            3251,
+            3252,
+            3253,
+            3254,
+            3255,
+            3256,
+            3257,
+            3258,
+            3259,
+            3260,
+            3261,
+            3262,
+            3263,
+            3264,
+            3265,
+            3266,
+            3267,
+            3268,
+            3269,
+            3270,
+            3271,
+            3272,
+            3273,
+            3274,
+            3275,
+            3276,
+            3277,
+            3278,
+            3279,
+            3280,
+            3281,
+            3282,
+            3283,
+            3284,
+            3285,
+            3286,
+            3287,
+            3288,
+            3289,
+            3290,
+            3291,
+            3292,
+            3293,
+            3294,
+            3295,
+            3296,
+            3297,
+            3298,
+            3299,
+            3300,
+            3301,
+            3302,
+            3303,
+            3304,
+            3305,
+            3306,
+            3307,
+            3308,
+            3309,
+            3310,
+            3311,
+            3312,
+            3313,
+            3314,
+            3315,
+            3316,
+            3317,
+            3318,
+            3319,
+            3320,
+            3321,
+            3322,
+            3323,
+            3324,
+            3325,
+            3326,
+            3327,
+            3328,
+            3329,
+            3330,
+            3331,
+            3332,
+            3333,
+            3334,
+            3335,
+            3336,
+            3337,
+            3338,
+            3339,
+            3340,
+            3341,
+            3342,
+            3343,
+            3344,
+            3345,
+            3346,
+            3347,
+            3348,
+            3349,
+            3350,
+            3351,
+            3352,
+            3353,
+            3354,
+            3355,
+            3356,
+            3357,
+            3358,
+            3359,
+            3360,
+            3361,
+            3362,
+            3363,
+            3364,
+            3365,
+            3366,
+            3367,
+            3368,
+            3369,
+            3370,
+            3371,
+            3372,
+            3373,
+            3374,
+            3375,
+            3376,
+            3377,
+            3378,
+            3379,
+            3380,
+            3381,
+            3382,
+            3383,
+            3384,
+            3385,
+            3386,
+            3387,
+            3388,
+            3389,
+            3390,
+            3391,
+            3392,
+            3393,
+            3394,
+            3395,
+            3396,
+            3397,
+            3398,
+            3399,
+            3400,
+            3401,
+            3402,
+            3403,
+            3404,
+            3405,
+            3406,
+            3407,
+            3408,
+            3409,
+            3410,
+            3411,
+            3412,
+            3413,
+            3414,
+            3415,
+            3416,
+            3417,
+            3418,
+            3419,
+            3420,
+            3421,
+            3422,
+            3423,
+            3424,
+            3425,
+            3426,
+            3427,
+            3428,
+            3429,
+            3430,
+            3431,
+            3432,
+            3433,
+            3434,
+            3435,
+            3436,
+            3437,
+            3438,
+            3439,
+            3440,
+            3441,
+            3442,
+            3443,
+            3444,
+            3445,
+            3446,
+            3447,
+            3448,
+            3449,
+            3450,
+            3451,
+            3452,
+            3453,
+            3454,
+            3455,
+            3456,
+            3457,
+            3458,
+            3459,
+            3460,
+            3461,
+            3462,
+            3463,
+            3464,
+            3465,
+            3466,
+            3467,
+            3468,
+            3469,
+            3470,
+            3471,
+            3472,
+            3473,
+            3474,
+            3475,
+            3476,
+            3477,
+            3478,
+            3479,
+            3480,
+            3481,
+            3482,
+            3483,
+            3484,
+            3485,
+            3486,
+            3487,
+            3488,
+            3489,
+            3490,
+            3491,
+            3492,
+            3493,
+            3494,
+            3495,
+            3496,
+            3497,
+            3498,
+            3499,
+            3500,
+            3501,
+            3502,
+            3503,
+            3504,
+            3505,
+            3506,
+            3507,
+            3508,
+            3509,
+            3510,
+            3511,
+            3512,
+            3513,
+            3514,
+            3515,
+            3516,
+            3517,
+            3518,
+            3519,
+            3520,
+            3521,
+            3522,
+            3523,
+            3524,
+            3525,
+            3526,
+            3527,
+            3528,
+            3529,
+            3530,
+            3531,
+            3532,
+            3533,
+            3534,
+            3535,
+            3536,
+            3537,
+            3538,
+            3539,
+            3540,
+            3541,
+            3542,
+            3543,
+            3544,
+            3545,
+            3546,
+            3547,
+            3548,
+            3549,
+            3550,
+            3551,
+            3552,
+            3553,
+            3554,
+            3555,
+            3556,
+            3557,
+            3558,
+            3559,
+            3560,
+            3561,
+            3562,
+            3563,
+            3564,
+            3565,
+            3566,
+            3567,
+            3568,
+            3569,
+            3570,
+            3571,
+            3572,
+            3573,
+            3574,
+            3575,
+            3576,
+            3577,
+            3578,
+            3579,
+            3580,
+            3581,
+            3582,
+            3583,
+            3584,
+            3585,
+            3586,
+            3587,
+            3588,
+            3589,
+            3590,
+            3591,
+            3592,
+            3593,
+            3594,
+            3595,
+            3596,
+            3597,
+            3598,
+            3599,
+            3600,
+            3601,
+            3602,
+            3603,
+            3604,
+            3605,
+            3606,
+            3607,
+            3608,
+            3609,
+            3610,
+            3611,
+            3612,
+            3613,
+            3614,
+            3615,
+            3616,
+            3617,
+            3618,
+            3619,
+            3620,
+            3621,
+            3622,
+            3623,
+            3624,
+            3625,
+            3626,
+            3627,
+            3628,
+            3629,
+            3630,
+            3631,
+            3632,
+            3633,
+            3634,
+            3635,
+            3636,
+            3637,
+            3638,
+            3639,
+            3640,
+            3641,
+            3642,
+            3643,
+            3644,
+            3645
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            96
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 476
+},
+{
+    "fields": {
+        "pkgname": "gnome-do",
+        "type_id": "gnome-do.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 477
+},
+{
+    "fields": {
+        "pkgname": "ekiga",
+        "type_id": "gnome-ekiga.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            97
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 478
+},
+{
+    "fields": {
+        "pkgname": "gnome-genius",
+        "type_id": "gnome-genius.desktop",
+        "keywords": [
+            1514,
+            2720,
+            3646,
+            3647,
+            3648,
+            3649,
+            3650,
+            3651,
+            3652,
+            3653,
+            3654,
+            3655,
+            3656,
+            3657,
+            3658,
+            3659,
+            3660,
+            3661,
+            3662,
+            3663,
+            3664,
+            3665,
+            3666,
+            3667,
+            3668,
+            3669,
+            3670,
+            3671,
+            3672,
+            3673,
+            3674,
+            3675,
+            3676,
+            3677,
+            3678,
+            3679,
+            3680,
+            3681,
+            3682,
+            3683,
+            3684,
+            3685,
+            3686,
+            3687,
+            3688,
+            3689,
+            3690,
+            3691,
+            3692,
+            3693,
+            3694,
+            3695,
+            3696,
+            3697,
+            3698,
+            3699,
+            3700,
+            3701,
+            3702,
+            3703,
+            3704,
+            3705,
+            3706,
+            3707,
+            3708,
+            3709,
+            3710,
+            3711,
+            3712,
+            3713
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            19,
+            21,
+            27,
+            92
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 479
+},
+{
+    "fields": {
+        "pkgname": "gkrellm",
+        "type_id": "gnome-gkrellm.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 480
+},
+{
+    "fields": {
+        "pkgname": "gnome-gmail",
+        "type_id": "gnome-gmail.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            22,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 481
+},
+{
+    "fields": {
+        "pkgname": "gnome-klotski",
+        "type_id": "gnome-klotski.desktop",
+        "keywords": [
+            198,
+            200,
+            2159,
+            2163,
+            2164,
+            2165,
+            2166,
+            2167,
+            2170,
+            2171,
+            2172,
+            2173,
+            2174,
+            2175,
+            2176,
+            2177,
+            2178,
+            2179,
+            2180,
+            2181,
+            2182,
+            2183,
+            2184,
+            2185,
+            2186,
+            2187,
+            2188,
+            2189,
+            2190,
+            2191,
+            2192,
+            2193,
+            2194,
+            2195,
+            2196,
+            2197,
+            2198,
+            2199,
+            2200,
+            2201,
+            2202,
+            2203,
+            2204,
+            2205,
+            2206,
+            2207,
+            2208,
+            2209,
+            2210,
+            2211,
+            2212,
+            2213,
+            2214,
+            2215,
+            2216,
+            2217,
+            2218,
+            2219,
+            2220,
+            2221,
+            2222,
+            2223,
+            2224,
+            2225,
+            2226,
+            2227,
+            2228,
+            2229,
+            2230,
+            2231,
+            2232,
+            2233,
+            2234,
+            2235,
+            2236,
+            2237,
+            2238,
+            2239,
+            2242,
+            2243,
+            2244,
+            2252,
+            2253,
+            2254,
+            2255,
+            2256,
+            2257,
+            2258,
+            2259,
+            2260,
+            2261,
+            2262,
+            2263,
+            2264,
+            2265,
+            2266,
+            2267,
+            2268,
+            2269,
+            2270,
+            2271,
+            2272,
+            2273,
+            2275,
+            2276,
+            2277,
+            2278,
+            2279,
+            2280,
+            2281,
+            2282,
+            2283,
+            2284,
+            2285,
+            2286,
+            2290,
+            2292,
+            2293,
+            2294,
+            2295,
+            2296,
+            2297,
+            2298,
+            2299,
+            2300,
+            2301,
+            2302,
+            2303,
+            2304,
+            2311,
+            2954,
+            3714,
+            3715,
+            3716,
+            3717,
+            3718,
+            3719,
+            3720,
+            3721,
+            3722,
+            3723,
+            3724,
+            3725,
+            3726,
+            3727,
+            3728,
+            3729,
+            3730,
+            3731,
+            3732,
+            3733,
+            3734,
+            3735,
+            3736,
+            3737,
+            3738,
+            3739,
+            3740,
+            3741,
+            3742,
+            3743,
+            3744,
+            3745,
+            3746,
+            3747,
+            3748,
+            3749,
+            3750,
+            3751,
+            3752,
+            3753,
+            3754,
+            3755,
+            3756,
+            3757,
+            3758,
+            3759,
+            3760,
+            3761,
+            3762,
+            3763,
+            3764,
+            3765,
+            3766,
+            3767
+        ],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 482
+},
+{
+    "fields": {
+        "pkgname": "gnome-mahjongg",
+        "type_id": "gnome-mahjongg.desktop",
+        "keywords": [
+            198,
+            2159,
+            2163,
+            2166,
+            2167,
+            2169,
+            2170,
+            2171,
+            2173,
+            2174,
+            2176,
+            2177,
+            2178,
+            2180,
+            2181,
+            2183,
+            2184,
+            2186,
+            2187,
+            2188,
+            2189,
+            2192,
+            2193,
+            2194,
+            2195,
+            2197,
+            2198,
+            2201,
+            2202,
+            2203,
+            2205,
+            2206,
+            2208,
+            2209,
+            2212,
+            2213,
+            2215,
+            2217,
+            2218,
+            2219,
+            2220,
+            2222,
+            2224,
+            2225,
+            2226,
+            2227,
+            2228,
+            2229,
+            2232,
+            2234,
+            2235,
+            2237,
+            2238,
+            2239,
+            2243,
+            2244,
+            2252,
+            2253,
+            2256,
+            2257,
+            2258,
+            2259,
+            2261,
+            2262,
+            2264,
+            2266,
+            2267,
+            2270,
+            2271,
+            2272,
+            2274,
+            2275,
+            2277,
+            2278,
+            2280,
+            2282,
+            2283,
+            2285,
+            2286,
+            2290,
+            2293,
+            2295,
+            2296,
+            2297,
+            2299,
+            2300,
+            2302,
+            2303,
+            2678,
+            2679,
+            2680,
+            2681,
+            2682,
+            2683,
+            2684,
+            2953,
+            2954,
+            3742,
+            3746,
+            3768,
+            3769,
+            3770,
+            3771,
+            3772,
+            3773,
+            3774,
+            3775,
+            3776,
+            3777,
+            3778,
+            3779,
+            3780,
+            3781,
+            3782,
+            3783,
+            3784,
+            3785,
+            3786,
+            3787,
+            3788,
+            3789,
+            3790,
+            3791,
+            3792,
+            3793,
+            3794,
+            3795,
+            3796,
+            3797,
+            3798,
+            3799,
+            3800,
+            3801,
+            3802,
+            3803,
+            3804,
+            3805,
+            3806,
+            3807,
+            3808,
+            3809,
+            3810,
+            3811,
+            3812,
+            3813,
+            3814,
+            3815,
+            3816,
+            3817,
+            3818,
+            3819,
+            3820,
+            3821,
+            3822,
+            3823,
+            3824,
+            3825,
+            3826,
+            3827,
+            3828,
+            3829,
+            3830,
+            3831,
+            3832,
+            3833,
+            3834,
+            3835,
+            3836,
+            3837,
+            3838,
+            3839,
+            3840,
+            3841,
+            3842,
+            3843,
+            3844,
+            3845,
+            3846,
+            3847,
+            3848,
+            3849,
+            3850,
+            3851,
+            3852,
+            3853,
+            3854,
+            3855,
+            3856,
+            3857,
+            3858,
+            3859,
+            3860,
+            3861,
+            3862
+        ],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            60
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 483
+},
+{
+    "fields": {
+        "pkgname": "gnome-mines",
+        "type_id": "gnome-mines.desktop",
+        "keywords": [
+            2183,
+            2223,
+            2224,
+            2226,
+            2227,
+            2228,
+            3791,
+            3819,
+            3863,
+            3864,
+            3865,
+            3866,
+            3867,
+            3868,
+            3869,
+            3870,
+            3871,
+            3872,
+            3873,
+            3874,
+            3875,
+            3876,
+            3877,
+            3878,
+            3879,
+            3880,
+            3881,
+            3882,
+            3883,
+            3884,
+            3885,
+            3886,
+            3887,
+            3888,
+            3889,
+            3890,
+            3891,
+            3892,
+            3893,
+            3894,
+            3895,
+            3896,
+            3897,
+            3898,
+            3899,
+            3900,
+            3901,
+            3902,
+            3903,
+            3904,
+            3905,
+            3906,
+            3907,
+            3908,
+            3909,
+            3910,
+            3911,
+            3912,
+            3913,
+            3914,
+            3915,
+            3916,
+            3917,
+            3918,
+            3919,
+            3920,
+            3921,
+            3922,
+            3923
+        ],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 484
+},
+{
+    "fields": {
+        "pkgname": "gnome-music",
+        "type_id": "gnome-music.desktop",
+        "keywords": [
+            473,
+            593,
+            1094,
+            1100,
+            1107,
+            1114,
+            1116,
+            3924,
+            3925,
+            3926,
+            3927,
+            3928,
+            3929,
+            3930,
+            3931,
+            3932,
+            3933,
+            3934,
+            3935,
+            3936,
+            3937,
+            3938,
+            3939,
+            3940,
+            3941,
+            3942,
+            3943,
+            3944,
+            3945,
+            3946,
+            3947,
+            3948,
+            3949,
+            3950,
+            3951,
+            3952,
+            3953,
+            3954,
+            3955,
+            3956,
+            3957,
+            3958,
+            3959,
+            3960,
+            3961,
+            3962,
+            3963,
+            3964,
+            3965,
+            3966,
+            3967,
+            3968,
+            3969,
+            3970,
+            3971,
+            3972,
+            3973,
+            3974,
+            3975,
+            3976,
+            3977,
+            3978,
+            3979,
+            3980,
+            3981,
+            3982,
+            3983,
+            3984,
+            3985,
+            3986,
+            3987,
+            3988,
+            3989,
+            3990,
+            3991,
+            3992
+        ],
+        "project_license": "(GPL-2.0-with-font-exception) AND LGPL-2.1+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 485
+},
+{
+    "fields": {
+        "pkgname": "gnome-nettool",
+        "type_id": "gnome-nettool.desktop",
+        "keywords": [
+            1619,
+            1652,
+            1683,
+            2109,
+            2114,
+            2117,
+            2120,
+            2125,
+            2134,
+            2141,
+            2144,
+            2153,
+            2157,
+            3993,
+            3994,
+            3995,
+            3996,
+            3997,
+            3998,
+            3999,
+            4000,
+            4001,
+            4002,
+            4003,
+            4004,
+            4005,
+            4006,
+            4007,
+            4008,
+            4009,
+            4010,
+            4011,
+            4012,
+            4013,
+            4014,
+            4015,
+            4016,
+            4017,
+            4018,
+            4019,
+            4020,
+            4021,
+            4022,
+            4023,
+            4024,
+            4025,
+            4026,
+            4027,
+            4028,
+            4029,
+            4030,
+            4031,
+            4032,
+            4033,
+            4034,
+            4035,
+            4036,
+            4037,
+            4038,
+            4039,
+            4040,
+            4041,
+            4042,
+            4043,
+            4044,
+            4045,
+            4046,
+            4047,
+            4048,
+            4049,
+            4050,
+            4051,
+            4052,
+            4053,
+            4054,
+            4055,
+            4056,
+            4057,
+            4058,
+            4059,
+            4060,
+            4061,
+            4062,
+            4063,
+            4064,
+            4065,
+            4066,
+            4067,
+            4068,
+            4069,
+            4070,
+            4071,
+            4072,
+            4073,
+            4074,
+            4075,
+            4076,
+            4077,
+            4078,
+            4079,
+            4080,
+            4081,
+            4082,
+            4083,
+            4084,
+            4085,
+            4086,
+            4087,
+            4088,
+            4089,
+            4090,
+            4091,
+            4092,
+            4093,
+            4094,
+            4095,
+            4096,
+            4097,
+            4098,
+            4099,
+            4100,
+            4101,
+            4102,
+            4103,
+            4104,
+            4105,
+            4106,
+            4107,
+            4108,
+            4109,
+            4110
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            4,
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 486
+},
+{
+    "fields": {
+        "pkgname": "gnome-nibbles",
+        "type_id": "gnome-nibbles.desktop",
+        "keywords": [
+            198,
+            2163,
+            2171,
+            2174,
+            2176,
+            2180,
+            2183,
+            2186,
+            2189,
+            2192,
+            2195,
+            2198,
+            2201,
+            2203,
+            2208,
+            2212,
+            2213,
+            2217,
+            2219,
+            2220,
+            2224,
+            2229,
+            2235,
+            2237,
+            2239,
+            2243,
+            2252,
+            2253,
+            2259,
+            2262,
+            2264,
+            2267,
+            2272,
+            2275,
+            2278,
+            2282,
+            2286,
+            2288,
+            2290,
+            2293,
+            2296,
+            2300,
+            2303,
+            2680,
+            2953,
+            2962,
+            3768,
+            3774,
+            3782,
+            3784,
+            3785,
+            3787,
+            3790,
+            3792,
+            3794,
+            3795,
+            3797,
+            3799,
+            3803,
+            3806,
+            3812,
+            3813,
+            3817,
+            3820,
+            3821,
+            3824,
+            3825,
+            3829,
+            3832,
+            3833,
+            3835,
+            3837,
+            3839,
+            3841,
+            3843,
+            3846,
+            3848,
+            3849,
+            3851,
+            3853,
+            3859,
+            3861,
+            4111,
+            4112,
+            4113,
+            4114,
+            4115,
+            4116,
+            4117,
+            4118,
+            4119,
+            4120,
+            4121,
+            4122,
+            4123,
+            4124,
+            4125,
+            4126,
+            4127,
+            4128,
+            4129,
+            4130,
+            4131,
+            4132,
+            4133,
+            4134,
+            4135,
+            4136,
+            4137,
+            4138,
+            4139,
+            4140,
+            4141,
+            4142,
+            4143,
+            4144,
+            4145,
+            4146,
+            4147,
+            4148,
+            4149,
+            4150,
+            4151,
+            4152,
+            4153,
+            4154,
+            4155,
+            4156,
+            4157,
+            4158,
+            4159,
+            4160,
+            4161,
+            4162,
+            4163,
+            4164,
+            4165,
+            4166,
+            4167
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 487
+},
+{
+    "fields": {
+        "pkgname": "gnome-phone-manager",
+        "type_id": "gnome-phone-manager.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            97
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 488
+},
+{
+    "fields": {
+        "pkgname": "gnome-pie",
+        "type_id": "gnome-pie.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 489
+},
+{
+    "fields": {
+        "pkgname": "gnome-power-manager",
+        "type_id": "gnome-power-statistics.desktop",
+        "keywords": [
+            4168,
+            4169,
+            4170,
+            4171,
+            4172,
+            4173,
+            4174,
+            4175,
+            4176,
+            4177,
+            4178,
+            4179,
+            4180,
+            4181,
+            4182,
+            4183,
+            4184,
+            4185,
+            4186,
+            4187,
+            4188,
+            4189,
+            4190,
+            4191,
+            4192,
+            4193,
+            4194,
+            4195,
+            4196,
+            4197,
+            4198,
+            4199,
+            4200,
+            4201,
+            4202,
+            4203,
+            4204,
+            4205,
+            4206,
+            4207,
+            4208,
+            4209,
+            4210,
+            4211,
+            4212,
+            4213,
+            4214,
+            4215,
+            4216,
+            4217,
+            4218,
+            4219,
+            4220,
+            4221,
+            4222,
+            4223,
+            4224,
+            4225,
+            4226,
+            4227,
+            4228,
+            4229,
+            4230,
+            4231,
+            4232,
+            4233,
+            4234,
+            4235,
+            4236,
+            4237,
+            4238,
+            4239,
+            4240,
+            4241,
+            4242,
+            4243,
+            4244,
+            4245,
+            4246,
+            4247,
+            4248,
+            4249,
+            4250,
+            4251,
+            4252,
+            4253,
+            4254,
+            4255,
+            4256,
+            4257,
+            4258,
+            4259,
+            4260,
+            4261,
+            4262,
+            4263,
+            4264,
+            4265,
+            4266,
+            4267,
+            4268,
+            4269,
+            4270,
+            4271,
+            4272,
+            4273,
+            4274,
+            4275,
+            4276,
+            4277,
+            4278,
+            4279,
+            4280,
+            4281,
+            4282,
+            4283,
+            4284,
+            4285,
+            4286,
+            4287,
+            4288,
+            4289,
+            4290,
+            4291,
+            4292,
+            4293,
+            4294,
+            4295,
+            4296,
+            4297,
+            4298,
+            4299,
+            4300,
+            4301,
+            4302,
+            4303,
+            4304,
+            4305,
+            4306,
+            4307,
+            4308,
+            4309,
+            4310,
+            4311,
+            4312,
+            4313,
+            4314,
+            4315,
+            4316
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 490
+},
+{
+    "fields": {
+        "pkgname": "gnome-robots",
+        "type_id": "gnome-robots.desktop",
+        "keywords": [
+            198,
+            2163,
+            2167,
+            2171,
+            2174,
+            2176,
+            2180,
+            2183,
+            2186,
+            2189,
+            2192,
+            2195,
+            2198,
+            2201,
+            2203,
+            2208,
+            2212,
+            2213,
+            2217,
+            2219,
+            2220,
+            2223,
+            2224,
+            2226,
+            2229,
+            2235,
+            2237,
+            2239,
+            2243,
+            2252,
+            2253,
+            2259,
+            2262,
+            2264,
+            2267,
+            2272,
+            2275,
+            2278,
+            2282,
+            2286,
+            2288,
+            2293,
+            2296,
+            2300,
+            2303,
+            4317,
+            4318,
+            4319,
+            4320,
+            4321,
+            4322,
+            4323,
+            4324,
+            4325,
+            4326,
+            4327,
+            4328,
+            4329,
+            4330,
+            4331,
+            4332,
+            4333,
+            4334,
+            4335,
+            4336,
+            4337,
+            4338,
+            4339,
+            4340,
+            4341,
+            4342,
+            4343,
+            4344,
+            4345,
+            4346,
+            4347,
+            4348,
+            4349,
+            4350,
+            4351,
+            4352,
+            4353,
+            4354,
+            4355,
+            4356,
+            4357,
+            4358,
+            4359,
+            4360,
+            4361,
+            4362,
+            4363,
+            4364,
+            4365,
+            4366,
+            4367,
+            4368,
+            4369,
+            4370,
+            4371,
+            4372,
+            4373,
+            4374,
+            4375,
+            4376,
+            4377,
+            4378,
+            4379,
+            4380,
+            4381,
+            4382,
+            4383,
+            4384,
+            4385,
+            4386,
+            4387,
+            4388,
+            4389,
+            4390
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 491
+},
+{
+    "fields": {
+        "pkgname": "gnome-schedule",
+        "type_id": "gnome-schedule.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 492
+},
+{
+    "fields": {
+        "pkgname": "gnome-search-tool",
+        "type_id": "gnome-search-tool.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            5,
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 493
+},
+{
+    "fields": {
+        "pkgname": "gnome-subtitles",
+        "type_id": "gnome-subtitles.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND (MPL-1.1 OR GPL-2.0+ OR LGPL-2.1+)",
+        "type": "desktop",
+        "categories": [
+            7,
+            56,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 494
+},
+{
+    "fields": {
+        "pkgname": "gnome-sudoku",
+        "type_id": "gnome-sudoku.desktop",
+        "keywords": [
+            4391,
+            4392,
+            4393,
+            4394,
+            4395,
+            4396,
+            4397,
+            4398,
+            4399,
+            4400,
+            4401,
+            4402,
+            4403,
+            4404,
+            4405,
+            4406,
+            4407,
+            4408,
+            4409,
+            4410,
+            4411,
+            4412,
+            4413,
+            4414,
+            4415,
+            4416,
+            4417,
+            4418,
+            4419,
+            4420,
+            4421,
+            4422,
+            4423,
+            4424,
+            4425,
+            4426,
+            4427,
+            4428,
+            4429,
+            4430,
+            4431,
+            4432,
+            4433,
+            4434,
+            4435,
+            4436,
+            4437,
+            4438,
+            4439,
+            4440,
+            4441,
+            4442,
+            4443,
+            4444,
+            4445,
+            4446,
+            4447,
+            4448,
+            4449,
+            4450,
+            4451,
+            4452,
+            4453,
+            4454
+        ],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 495
+},
+{
+    "fields": {
+        "pkgname": "gnome-system-log",
+        "type_id": "gnome-system-log.desktop",
+        "keywords": [
+            842,
+            844,
+            845,
+            850,
+            852,
+            853,
+            859,
+            860,
+            862,
+            863,
+            866,
+            2552,
+            2554,
+            2558,
+            2569,
+            2570,
+            2572,
+            2573,
+            4455,
+            4456,
+            4457,
+            4458,
+            4459,
+            4460,
+            4461,
+            4462,
+            4463,
+            4464,
+            4465,
+            4466,
+            4467,
+            4468,
+            4469,
+            4470,
+            4471,
+            4472,
+            4473,
+            4474,
+            4475,
+            4476,
+            4477,
+            4478,
+            4479,
+            4480,
+            4481,
+            4482,
+            4483,
+            4484,
+            4485,
+            4486,
+            4487,
+            4488,
+            4489,
+            4490,
+            4491,
+            4492,
+            4493,
+            4494,
+            4495,
+            4496,
+            4497,
+            4498,
+            4499,
+            4500,
+            4501,
+            4502,
+            4503,
+            4504,
+            4505,
+            4506,
+            4507,
+            4508,
+            4509,
+            4510,
+            4511,
+            4512,
+            4513,
+            4514,
+            4515,
+            4516,
+            4517,
+            4518,
+            4519,
+            4520,
+            4521,
+            4522,
+            4523,
+            4524,
+            4525,
+            4526,
+            4527,
+            4528,
+            4529,
+            4530,
+            4531,
+            4532,
+            4533,
+            4534,
+            4535,
+            4536,
+            4537,
+            4538,
+            4539,
+            4540,
+            4541,
+            4542,
+            4543,
+            4544,
+            4545,
+            4546,
+            4547,
+            4548,
+            4549,
+            4550,
+            4551,
+            4552,
+            4553,
+            4554,
+            4555,
+            4556,
+            4557,
+            4558,
+            4559,
+            4560,
+            4561,
+            4562,
+            4563,
+            4564,
+            4565,
+            4566,
+            4567,
+            4568,
+            4569,
+            4570,
+            4571,
+            4572,
+            4573,
+            4574,
+            4575,
+            4576,
+            4577,
+            4578,
+            4579,
+            4580,
+            4581,
+            4582,
+            4583,
+            4584,
+            4585,
+            4586,
+            4587,
+            4588
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 496
+},
+{
+    "fields": {
+        "pkgname": "gnome-system-monitor",
+        "type_id": "gnome-system-monitor.desktop",
+        "keywords": [
+            1004,
+            1565,
+            1652,
+            1724,
+            1867,
+            1914,
+            1970,
+            1981,
+            1989,
+            2008,
+            2061,
+            2070,
+            2092,
+            2097,
+            2102,
+            2114,
+            2128,
+            2130,
+            2134,
+            2137,
+            2157,
+            3639,
+            4002,
+            4003,
+            4012,
+            4025,
+            4026,
+            4035,
+            4036,
+            4038,
+            4049,
+            4066,
+            4089,
+            4090,
+            4092,
+            4093,
+            4107,
+            4173,
+            4259,
+            4589,
+            4590,
+            4591,
+            4592,
+            4593,
+            4594,
+            4595,
+            4596,
+            4597,
+            4598,
+            4599,
+            4600,
+            4601,
+            4602,
+            4603,
+            4604,
+            4605,
+            4606,
+            4607,
+            4608,
+            4609,
+            4610,
+            4611,
+            4612,
+            4613,
+            4614,
+            4615,
+            4616,
+            4617,
+            4618,
+            4619,
+            4620,
+            4621,
+            4622,
+            4623,
+            4624,
+            4625,
+            4626,
+            4627,
+            4628,
+            4629,
+            4630,
+            4631,
+            4632,
+            4633,
+            4634,
+            4635,
+            4636,
+            4637,
+            4638,
+            4639,
+            4640,
+            4641,
+            4642,
+            4643,
+            4644,
+            4645,
+            4646,
+            4647,
+            4648,
+            4649,
+            4650,
+            4651,
+            4652,
+            4653,
+            4654,
+            4655,
+            4656,
+            4657,
+            4658,
+            4659,
+            4660,
+            4661,
+            4662,
+            4663,
+            4664,
+            4665,
+            4666,
+            4667,
+            4668,
+            4669,
+            4670,
+            4671,
+            4672,
+            4673,
+            4674,
+            4675,
+            4676,
+            4677,
+            4678,
+            4679,
+            4680,
+            4681,
+            4682,
+            4683,
+            4684,
+            4685,
+            4686,
+            4687,
+            4688,
+            4689,
+            4690,
+            4691,
+            4692,
+            4693,
+            4694,
+            4695,
+            4696,
+            4697,
+            4698,
+            4699,
+            4700,
+            4701,
+            4702,
+            4703,
+            4704,
+            4705,
+            4706,
+            4707,
+            4708,
+            4709,
+            4710,
+            4711,
+            4712,
+            4713,
+            4714,
+            4715,
+            4716,
+            4717,
+            4718,
+            4719,
+            4720,
+            4721,
+            4722,
+            4723,
+            4724,
+            4725,
+            4726,
+            4727,
+            4728,
+            4729,
+            4730,
+            4731,
+            4732,
+            4733,
+            4734,
+            4735,
+            4736,
+            4737,
+            4738,
+            4739,
+            4740,
+            4741,
+            4742,
+            4743,
+            4744,
+            4745,
+            4746,
+            4747,
+            4748,
+            4749,
+            4750,
+            4751,
+            4752,
+            4753,
+            4754,
+            4755,
+            4756,
+            4757,
+            4758,
+            4759,
+            4760,
+            4761,
+            4762,
+            4763,
+            4764,
+            4765,
+            4766,
+            4767,
+            4768,
+            4769,
+            4770,
+            4771,
+            4772,
+            4773,
+            4774,
+            4775,
+            4776,
+            4777,
+            4778,
+            4779,
+            4780,
+            4781,
+            4782,
+            4783,
+            4784,
+            4785,
+            4786,
+            4787,
+            4788,
+            4789,
+            4790,
+            4791,
+            4792,
+            4793,
+            4794,
+            4795,
+            4796,
+            4797,
+            4798,
+            4799,
+            4800,
+            4801,
+            4802,
+            4803,
+            4804,
+            4805,
+            4806,
+            4807,
+            4808,
+            4809,
+            4810,
+            4811,
+            4812,
+            4813,
+            4814,
+            4815,
+            4816,
+            4817,
+            4818,
+            4819,
+            4820,
+            4821,
+            4822,
+            4823,
+            4824,
+            4825,
+            4826,
+            4827,
+            4828,
+            4829,
+            4830,
+            4831,
+            4832,
+            4833,
+            4834,
+            4835,
+            4836,
+            4837,
+            4838,
+            4839,
+            4840,
+            4841,
+            4842,
+            4843,
+            4844,
+            4845,
+            4846,
+            4847,
+            4848,
+            4849,
+            4850,
+            4851,
+            4852,
+            4853,
+            4854,
+            4855,
+            4856,
+            4857,
+            4858,
+            4859,
+            4860,
+            4861,
+            4862,
+            4863,
+            4864,
+            4865,
+            4866,
+            4867,
+            4868,
+            4869,
+            4870,
+            4871,
+            4872,
+            4873,
+            4874,
+            4875,
+            4876,
+            4877,
+            4878,
+            4879,
+            4880,
+            4881,
+            4882,
+            4883,
+            4884,
+            4885,
+            4886,
+            4887,
+            4888,
+            4889,
+            4890,
+            4891,
+            4892,
+            4893,
+            4894,
+            4895,
+            4896,
+            4897,
+            4898,
+            4899,
+            4900,
+            4901,
+            4902,
+            4903,
+            4904,
+            4905,
+            4906,
+            4907,
+            4908,
+            4909,
+            4910,
+            4911,
+            4912,
+            4913,
+            4914,
+            4915,
+            4916,
+            4917,
+            4918,
+            4919,
+            4920,
+            4921,
+            4922,
+            4923,
+            4924,
+            4925,
+            4926,
+            4927,
+            4928,
+            4929,
+            4930,
+            4931,
+            4932,
+            4933,
+            4934,
+            4935,
+            4936,
+            4937,
+            4938,
+            4939,
+            4940,
+            4941,
+            4942,
+            4943,
+            4944,
+            4945,
+            4946,
+            4947,
+            4948,
+            4949,
+            4950,
+            4951,
+            4952,
+            4953,
+            4954,
+            4955,
+            4956,
+            4957,
+            4958,
+            4959,
+            4960,
+            4961,
+            4962,
+            4963,
+            4964,
+            4965,
+            4966,
+            4967,
+            4968,
+            4969,
+            4970,
+            4971,
+            4972,
+            4973,
+            4974,
+            4975,
+            4976,
+            4977,
+            4978,
+            4979,
+            4980,
+            4981,
+            4982,
+            4983,
+            4984,
+            4985,
+            4986,
+            4987,
+            4988,
+            4989,
+            4990,
+            4991,
+            4992,
+            4993,
+            4994,
+            4995,
+            4996,
+            4997,
+            4998,
+            4999,
+            5000,
+            5001,
+            5002,
+            5003,
+            5004,
+            5005,
+            5006,
+            5007,
+            5008,
+            5009,
+            5010,
+            5011,
+            5012,
+            5013,
+            5014,
+            5015,
+            5016,
+            5017,
+            5018,
+            5019,
+            5020,
+            5021,
+            5022,
+            5023,
+            5024,
+            5025,
+            5026,
+            5027,
+            5028,
+            5029,
+            5030,
+            5031,
+            5032,
+            5033,
+            5034,
+            5035,
+            5036,
+            5037,
+            5038,
+            5039,
+            5040,
+            5041,
+            5042,
+            5043,
+            5044,
+            5045,
+            5046,
+            5047,
+            5048,
+            5049,
+            5050,
+            5051,
+            5052,
+            5053,
+            5054,
+            5055,
+            5056,
+            5057,
+            5058,
+            5059,
+            5060,
+            5061,
+            5062,
+            5063,
+            5064,
+            5065,
+            5066,
+            5067,
+            5068,
+            5069,
+            5070,
+            5071,
+            5072,
+            5073,
+            5074,
+            5075,
+            5076,
+            5077,
+            5078,
+            5079,
+            5080,
+            5081,
+            5082,
+            5083,
+            5084,
+            5085,
+            5086,
+            5087,
+            5088,
+            5089,
+            5090,
+            5091,
+            5092,
+            5093,
+            5094,
+            5095,
+            5096,
+            5097,
+            5098,
+            5099,
+            5100,
+            5101
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 497
+},
+{
+    "fields": {
+        "pkgname": "gnome-tetravex",
+        "type_id": "gnome-tetravex.desktop",
+        "keywords": [
+            198,
+            200,
+            2163,
+            2164,
+            2165,
+            2168,
+            2171,
+            2172,
+            2174,
+            2175,
+            2176,
+            2177,
+            2179,
+            2180,
+            2182,
+            2183,
+            2185,
+            2186,
+            2189,
+            2190,
+            2191,
+            2192,
+            2195,
+            2196,
+            2198,
+            2199,
+            2200,
+            2201,
+            2203,
+            2204,
+            2207,
+            2208,
+            2210,
+            2211,
+            2212,
+            2213,
+            2214,
+            2216,
+            2217,
+            2219,
+            2220,
+            2221,
+            2223,
+            2224,
+            2226,
+            2227,
+            2228,
+            2229,
+            2230,
+            2231,
+            2233,
+            2235,
+            2236,
+            2237,
+            2239,
+            2242,
+            2243,
+            2252,
+            2253,
+            2254,
+            2255,
+            2259,
+            2260,
+            2262,
+            2263,
+            2264,
+            2265,
+            2267,
+            2268,
+            2269,
+            2272,
+            2273,
+            2275,
+            2276,
+            2278,
+            2279,
+            2281,
+            2282,
+            2284,
+            2286,
+            2287,
+            2288,
+            2296,
+            2298,
+            2300,
+            2301,
+            2303,
+            2304,
+            2680,
+            2953,
+            3748,
+            3768,
+            3769,
+            3772,
+            3774,
+            3782,
+            3784,
+            3785,
+            3787,
+            3790,
+            3792,
+            3794,
+            3795,
+            3799,
+            3801,
+            3803,
+            3806,
+            3812,
+            3813,
+            3817,
+            3820,
+            3821,
+            3824,
+            3825,
+            3829,
+            3832,
+            3833,
+            3835,
+            3837,
+            3839,
+            3841,
+            3843,
+            3846,
+            3848,
+            3849,
+            3851,
+            3859,
+            3861,
+            4129,
+            4145,
+            4159,
+            4364,
+            5102,
+            5103,
+            5104,
+            5105,
+            5106
+        ],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 498
+},
+{
+    "fields": {
+        "pkgname": "gnome-tweak-tool",
+        "type_id": "gnome-tweak-tool.desktop",
+        "keywords": [
+            600,
+            601,
+            610,
+            615,
+            628,
+            630,
+            635,
+            652,
+            655,
+            663,
+            664,
+            682,
+            685,
+            686,
+            688,
+            689,
+            697,
+            713,
+            716,
+            718,
+            2963,
+            2964,
+            2970,
+            2971,
+            2972,
+            2973,
+            2984,
+            2985,
+            2986,
+            2987,
+            2990,
+            2991,
+            2994,
+            2996,
+            2997,
+            3002,
+            3003,
+            3004,
+            3007,
+            3008,
+            3013,
+            3016,
+            3018,
+            3019,
+            3020,
+            3021,
+            3023,
+            3024,
+            3025,
+            3026,
+            3031,
+            3032,
+            3034,
+            3041,
+            3042,
+            3051,
+            3052,
+            3053,
+            3054,
+            3055,
+            3057,
+            3058,
+            3062,
+            3063,
+            3065,
+            3068,
+            3075,
+            3076,
+            3077,
+            3079,
+            3080,
+            3100,
+            3101,
+            3102,
+            4886,
+            5107,
+            5108,
+            5109,
+            5110,
+            5111,
+            5112,
+            5113,
+            5114,
+            5115,
+            5116,
+            5117,
+            5118,
+            5119,
+            5120,
+            5121,
+            5122,
+            5123,
+            5124,
+            5125,
+            5126,
+            5127,
+            5128,
+            5129,
+            5130,
+            5131,
+            5132,
+            5133,
+            5134,
+            5135,
+            5136,
+            5137,
+            5138,
+            5139,
+            5140,
+            5141,
+            5142,
+            5143,
+            5144,
+            5145,
+            5146,
+            5147,
+            5148,
+            5149,
+            5150,
+            5151,
+            5152,
+            5153,
+            5154,
+            5155,
+            5156,
+            5157,
+            5158,
+            5159,
+            5160,
+            5161,
+            5162,
+            5163,
+            5164,
+            5165,
+            5166,
+            5167,
+            5168,
+            5169,
+            5170,
+            5171,
+            5172,
+            5173,
+            5174,
+            5175,
+            5176,
+            5177,
+            5178,
+            5179,
+            5180,
+            5181,
+            5182,
+            5183,
+            5184,
+            5185,
+            5186,
+            5187,
+            5188,
+            5189,
+            5190,
+            5191,
+            5192,
+            5193,
+            5194,
+            5195,
+            5196,
+            5197,
+            5198,
+            5199,
+            5200,
+            5201,
+            5202,
+            5203,
+            5204,
+            5205,
+            5206,
+            5207,
+            5208,
+            5209,
+            5210,
+            5211,
+            5212,
+            5213,
+            5214,
+            5215,
+            5216,
+            5217,
+            5218,
+            5219,
+            5220,
+            5221,
+            5222,
+            5223,
+            5224,
+            5225,
+            5226,
+            5227,
+            5228,
+            5229,
+            5230,
+            5231,
+            5232,
+            5233,
+            5234,
+            5235,
+            5236,
+            5237,
+            5238,
+            5239,
+            5240,
+            5241,
+            5242,
+            5243,
+            5244,
+            5245,
+            5246,
+            5247,
+            5248,
+            5249,
+            5250,
+            5251,
+            5252,
+            5253,
+            5254,
+            5255,
+            5256,
+            5257,
+            5258,
+            5259,
+            5260,
+            5261,
+            5262,
+            5263,
+            5264,
+            5265,
+            5266,
+            5267,
+            5268,
+            5269,
+            5270,
+            5271,
+            5272,
+            5273,
+            5274,
+            5275,
+            5276,
+            5277,
+            5278,
+            5279,
+            5280,
+            5281,
+            5282,
+            5283,
+            5284,
+            5285,
+            5286,
+            5287,
+            5288,
+            5289,
+            5290,
+            5291,
+            5292,
+            5293,
+            5294,
+            5295,
+            5296,
+            5297,
+            5298,
+            5299,
+            5300,
+            5301,
+            5302,
+            5303,
+            5304,
+            5305,
+            5306,
+            5307,
+            5308,
+            5309,
+            5310,
+            5311,
+            5312,
+            5313,
+            5314,
+            5315,
+            5316,
+            5317,
+            5318,
+            5319,
+            5320,
+            5321,
+            5322,
+            5323,
+            5324,
+            5325,
+            5326,
+            5327,
+            5328,
+            5329,
+            5330,
+            5331,
+            5332,
+            5333,
+            5334,
+            5335,
+            5336,
+            5337,
+            5338,
+            5339,
+            5340,
+            5341,
+            5342,
+            5343,
+            5344,
+            5345,
+            5346,
+            5347,
+            5348,
+            5349,
+            5350,
+            5351,
+            5352,
+            5353,
+            5354,
+            5355,
+            5356,
+            5357,
+            5358,
+            5359,
+            5360,
+            5361,
+            5362,
+            5363,
+            5364,
+            5365,
+            5366,
+            5367,
+            5368,
+            5369,
+            5370,
+            5371,
+            5372,
+            5373,
+            5374,
+            5375,
+            5376,
+            5377,
+            5378,
+            5379,
+            5380,
+            5381,
+            5382,
+            5383,
+            5384,
+            5385,
+            5386,
+            5387,
+            5388,
+            5389,
+            5390,
+            5391,
+            5392,
+            5393,
+            5394,
+            5395,
+            5396,
+            5397,
+            5398,
+            5399,
+            5400,
+            5401,
+            5402
+        ],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 499
+},
+{
+    "fields": {
+        "pkgname": "gnomint",
+        "type_id": "gnomint.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            68
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 500
+},
+{
+    "fields": {
+        "pkgname": "gnote",
+        "type_id": "gnote.desktop",
+        "keywords": [
+            202,
+            215,
+            223,
+            227,
+            233,
+            248,
+            249,
+            263,
+            276,
+            282,
+            289,
+            290,
+            292,
+            301,
+            2080,
+            5403,
+            5404,
+            5405,
+            5406,
+            5407,
+            5408,
+            5409,
+            5410,
+            5411,
+            5412,
+            5413,
+            5414,
+            5415,
+            5416,
+            5417,
+            5418,
+            5419,
+            5420,
+            5421,
+            5422,
+            5423,
+            5424,
+            5425,
+            5426,
+            5427,
+            5428,
+            5429,
+            5430,
+            5431,
+            5432,
+            5433,
+            5434,
+            5435,
+            5436,
+            5437,
+            5438,
+            5439,
+            5440,
+            5441,
+            5442,
+            5443,
+            5444,
+            5445,
+            5446,
+            5447,
+            5448,
+            5449,
+            5450,
+            5451,
+            5452,
+            5453,
+            5454,
+            5455,
+            5456,
+            5457,
+            5458,
+            5459,
+            5460,
+            5461,
+            5462,
+            5463,
+            5464,
+            5465,
+            5466,
+            5467,
+            5468,
+            5469,
+            5470,
+            5471,
+            5472,
+            5473,
+            5474,
+            5475,
+            5476,
+            5477,
+            5478
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 501
+},
+{
+    "fields": {
+        "pkgname": "gnu-free-fonts-common",
+        "type_id": "gnu-free",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 502
+},
+{
+    "fields": {
+        "pkgname": "gnu-smalltalk",
+        "type_id": "gnu-smalltalk.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 503
+},
+{
+    "fields": {
+        "pkgname": "gnucash",
+        "type_id": "gnucash.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            79
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 504
+},
+{
+    "fields": {
+        "pkgname": "gnumed",
+        "type_id": "gnumed-client.desktop",
+        "keywords": [
+            5479,
+            5480,
+            5481,
+            5482,
+            5483,
+            5484,
+            5485,
+            5486,
+            5487,
+            5488
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            39
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 505
+},
+{
+    "fields": {
+        "pkgname": "gnumeric",
+        "type_id": "gnumeric.desktop",
+        "keywords": [
+            2720,
+            5489,
+            5490,
+            5491,
+            5492,
+            5493
+        ],
+        "project_license": "GPL-2.0+ AND GPL-3.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            13,
+            27,
+            98
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 506
+},
+{
+    "fields": {
+        "pkgname": "gnurobbo",
+        "type_id": "gnurobbo.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 507
+},
+{
+    "fields": {
+        "pkgname": "gobby05",
+        "type_id": "gobby-0.5.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 508
+},
+{
+    "fields": {
+        "pkgname": "gobby",
+        "type_id": "gobby.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 509
+},
+{
+    "fields": {
+        "pkgname": "gogui",
+        "type_id": "gogui.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            49,
+            60
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 510
+},
+{
+    "fields": {
+        "pkgname": "goldendict",
+        "type_id": "goldendict.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            19,
+            59
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 511
+},
+{
+    "fields": {
+        "pkgname": "gonvert",
+        "type_id": "gonvert.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 512
+},
+{
+    "fields": {
+        "pkgname": "google-croscore-arimo-fonts",
+        "type_id": "google-croscore",
+        "keywords": [],
+        "project_license": "Apache-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 513
+},
+{
+    "fields": {
+        "pkgname": "google-crosextra-caladea-fonts",
+        "type_id": "google-crosextra-caladea",
+        "keywords": [],
+        "project_license": "Apache-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 514
+},
+{
+    "fields": {
+        "pkgname": "google-crosextra-carlito-fonts",
+        "type_id": "google-crosextra-carlito",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 515
+},
+{
+    "fields": {
+        "pkgname": "google-droid-kufi-fonts",
+        "type_id": "google-droid-kufi",
+        "keywords": [],
+        "project_license": "Apache-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 516
+},
+{
+    "fields": {
+        "pkgname": "google-droid-sans-fonts",
+        "type_id": "google-droid-sans",
+        "keywords": [],
+        "project_license": "Apache-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 517
+},
+{
+    "fields": {
+        "pkgname": "google-droid-sans-mono-fonts",
+        "type_id": "google-droid-sans-mono",
+        "keywords": [],
+        "project_license": "Apache-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 518
+},
+{
+    "fields": {
+        "pkgname": "google-droid-serif-fonts",
+        "type_id": "google-droid-serif",
+        "keywords": [],
+        "project_license": "Apache-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 519
+},
+{
+    "fields": {
+        "pkgname": "google-noto-color-emoji-fonts",
+        "type_id": "google-noto",
+        "keywords": [],
+        "project_license": "Apache-2.0",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 520
+},
+{
+    "fields": {
+        "pkgname": "google-roboto-condensed-fonts",
+        "type_id": "google-roboto",
+        "keywords": [],
+        "project_license": "Apache-2.0 AND CC0-1.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 521
+},
+{
+    "fields": {
+        "pkgname": "gourmet",
+        "type_id": "gourmet.desktop",
+        "keywords": [
+            5494,
+            5495,
+            5496,
+            5497,
+            5498
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 522
+},
+{
+    "fields": {
+        "pkgname": "gparted",
+        "type_id": "gparted.desktop",
+        "keywords": [
+            379,
+            3142,
+            3181,
+            3502,
+            3514,
+            5499,
+            5500,
+            5501,
+            5502,
+            5503,
+            5504,
+            5505,
+            5506,
+            5507,
+            5508,
+            5509,
+            5510,
+            5511,
+            5512,
+            5513,
+            5514,
+            5515
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            99
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 523
+},
+{
+    "fields": {
+        "pkgname": "gphotoframe",
+        "type_id": "gphotoframe.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0 AND GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            14,
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 524
+},
+{
+    "fields": {
+        "pkgname": "gphpedit",
+        "type_id": "gphpedit.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 525
+},
+{
+    "fields": {
+        "pkgname": "gpick",
+        "type_id": "gpick.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 526
+},
+{
+    "fields": {
+        "pkgname": "gnome-packagekit-installer",
+        "type_id": "gpk-application.desktop",
+        "keywords": [
+            615,
+            655,
+            680,
+            686,
+            689,
+            2963,
+            2983,
+            2990,
+            2991,
+            2997,
+            3003,
+            3005,
+            3008,
+            3018,
+            3021,
+            3024,
+            3032,
+            3034,
+            3041,
+            3052,
+            3058,
+            3063,
+            3068,
+            3074,
+            3075,
+            3077,
+            3080,
+            3102,
+            5183,
+            5315,
+            5516,
+            5517,
+            5518,
+            5519,
+            5520,
+            5521,
+            5522,
+            5523,
+            5524,
+            5525,
+            5526,
+            5527,
+            5528,
+            5529,
+            5530,
+            5531,
+            5532,
+            5533,
+            5534,
+            5535,
+            5536,
+            5537,
+            5538,
+            5539,
+            5540,
+            5541,
+            5542,
+            5543,
+            5544,
+            5545,
+            5546,
+            5547,
+            5548,
+            5549,
+            5550,
+            5551,
+            5552,
+            5553,
+            5554,
+            5555,
+            5556,
+            5557,
+            5558,
+            5559,
+            5560,
+            5561,
+            5562,
+            5563,
+            5564,
+            5565,
+            5566,
+            5567,
+            5568,
+            5569,
+            5570,
+            5571,
+            5572,
+            5573,
+            5574,
+            5575,
+            5576,
+            5577,
+            5578,
+            5579,
+            5580,
+            5581,
+            5582,
+            5583,
+            5584,
+            5585,
+            5586,
+            5587,
+            5588,
+            5589,
+            5590,
+            5591,
+            5592,
+            5593,
+            5594,
+            5595,
+            5596,
+            5597,
+            5598,
+            5599,
+            5600,
+            5601,
+            5602,
+            5603,
+            5604,
+            5605,
+            5606,
+            5607,
+            5608,
+            5609,
+            5610,
+            5611,
+            5612,
+            5613,
+            5614,
+            5615,
+            5616,
+            5617,
+            5618,
+            5619,
+            5620,
+            5621,
+            5622,
+            5623,
+            5624,
+            5625,
+            5626,
+            5627,
+            5628,
+            5629,
+            5630,
+            5631,
+            5632,
+            5633,
+            5634,
+            5635,
+            5636,
+            5637,
+            5638,
+            5639,
+            5640,
+            5641,
+            5642,
+            5643,
+            5644,
+            5645,
+            5646,
+            5647,
+            5648,
+            5649,
+            5650,
+            5651,
+            5652,
+            5653,
+            5654,
+            5655,
+            5656,
+            5657,
+            5658,
+            5659,
+            5660,
+            5661,
+            5662,
+            5663,
+            5664,
+            5665,
+            5666,
+            5667,
+            5668,
+            5669,
+            5670,
+            5671,
+            5672,
+            5673,
+            5674,
+            5675
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            50,
+            51
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 527
+},
+{
+    "fields": {
+        "pkgname": "gnome-packagekit-updater",
+        "type_id": "gpk-update-viewer.desktop",
+        "keywords": [
+            5560,
+            5567,
+            5676,
+            5677,
+            5678,
+            5679,
+            5680,
+            5681,
+            5682,
+            5683,
+            5684,
+            5685,
+            5686,
+            5687,
+            5688,
+            5689,
+            5690,
+            5691,
+            5692,
+            5693,
+            5694,
+            5695,
+            5696,
+            5697,
+            5698,
+            5699,
+            5700,
+            5701,
+            5702,
+            5703,
+            5704,
+            5705,
+            5706,
+            5707,
+            5708,
+            5709,
+            5710,
+            5711,
+            5712,
+            5713,
+            5714,
+            5715,
+            5716,
+            5717,
+            5718,
+            5719,
+            5720,
+            5721,
+            5722,
+            5723,
+            5724,
+            5725,
+            5726,
+            5727,
+            5728,
+            5729,
+            5730,
+            5731,
+            5732,
+            5733,
+            5734,
+            5735,
+            5736,
+            5737,
+            5738,
+            5739,
+            5740,
+            5741,
+            5742,
+            5743
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 528
+},
+{
+    "fields": {
+        "pkgname": "gpodder",
+        "type_id": "gpodder.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 529
+},
+{
+    "fields": {
+        "pkgname": "gpredict",
+        "type_id": "gpredict.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            23,
+            69,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 530
+},
+{
+    "fields": {
+        "pkgname": "gpsbabel-gui",
+        "type_id": "gpsbabel.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            19,
+            25
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 531
+},
+{
+    "fields": {
+        "pkgname": "gpsim",
+        "type_id": "gpsim.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 532
+},
+{
+    "fields": {
+        "pkgname": "gpx-viewer",
+        "type_id": "gpx-viewer.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            87
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 533
+},
+{
+    "fields": {
+        "pkgname": "gqrx",
+        "type_id": "gqrx.desktop",
+        "keywords": [
+            5744,
+            5745,
+            5746
+        ],
+        "project_license": "GPL-3.0+ AND GPL-2.0+ AND BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            23,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 534
+},
+{
+    "fields": {
+        "pkgname": "gramps",
+        "type_id": "gramps.desktop",
+        "keywords": [
+            5747,
+            5748,
+            5749,
+            5750,
+            5751,
+            5752,
+            5753,
+            5754,
+            5755,
+            5756,
+            5757,
+            5758,
+            5759,
+            5760,
+            5761,
+            5762,
+            5763,
+            5764,
+            5765,
+            5766,
+            5767,
+            5768,
+            5769,
+            5770,
+            5771,
+            5772,
+            5773,
+            5774,
+            5775,
+            5776,
+            5777,
+            5778,
+            5779,
+            5780,
+            5781,
+            5782,
+            5783,
+            5784,
+            5785,
+            5786,
+            5787,
+            5788,
+            5789,
+            5790,
+            5791,
+            5792,
+            5793,
+            5794,
+            5795,
+            5796,
+            5797,
+            5798,
+            5799,
+            5800,
+            5801,
+            5802,
+            5803,
+            5804,
+            5805,
+            5806,
+            5807
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 535
+},
+{
+    "fields": {
+        "pkgname": "rasmol-gtk",
+        "type_id": "grasmol.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            18,
+            21,
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 536
+},
+{
+    "fields": {
+        "pkgname": "grass",
+        "type_id": "grass.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            25,
+            100
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 537
+},
+{
+    "fields": {
+        "pkgname": "gretl",
+        "type_id": "gretl.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND BSD-3-Clause AND MIT",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            27,
+            101
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 538
+},
+{
+    "fields": {
+        "pkgname": "grig",
+        "type_id": "grig.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 539
+},
+{
+    "fields": {
+        "pkgname": "grimmer-proggy-tinysz-fonts",
+        "type_id": "grimmer-proggy-tinysz",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 540
+},
+{
+    "fields": {
+        "pkgname": "grisbi",
+        "type_id": "grisbi.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            79
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 541
+},
+{
+    "fields": {
+        "pkgname": "groovy",
+        "type_id": "groovy.desktop",
+        "keywords": [],
+        "project_license": "Apache-2.0 AND BSD-3-Clause AND EPL-1.0 AND Public Domain AND CC-BY-3.0",
+        "type": "desktop",
+        "categories": [
+            11,
+            45,
+            49
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 542
+},
+{
+    "fields": {
+        "pkgname": "grsync",
+        "type_id": "grsync.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            76
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 543
+},
+{
+    "fields": {
+        "pkgname": "gscan2pdf",
+        "type_id": "gscan2pdf.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            26,
+            36
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 544
+},
+{
+    "fields": {
+        "pkgname": "gsmartcontrol",
+        "type_id": "gsmartcontrol.desktop",
+        "keywords": [],
+        "project_license": "(GPL-2.0 OR GPL-3.0) AND BSD-3-Clause AND Zlib AND BSL-1.0 AND MIT",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 545
+},
+{
+    "fields": {
+        "pkgname": "gspectrum",
+        "type_id": "gspectrum.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            18,
+            19,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 546
+},
+{
+    "fields": {
+        "pkgname": "gst-inspector",
+        "type_id": "gst-inspector.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 547
+},
+{
+    "fields": {
+        "pkgname": "gstreamer1-plugins-bad-free",
+        "type_id": "gstreamer-bad-free",
+        "keywords": [
+            5808,
+            5809,
+            5810,
+            5811,
+            5812,
+            5813,
+            5814
+        ],
+        "project_license": "LGPL-2.1+ AND LGPL-2.1",
+        "type": "codec",
+        "categories": [
+            8,
+            102
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 548
+},
+{
+    "fields": {
+        "pkgname": "gstreamer1-plugins-bad-freeworld",
+        "type_id": "gstreamer-bad-freeworld",
+        "keywords": [
+            5815,
+            5816,
+            5817,
+            5818,
+            5819,
+            5820,
+            5821,
+            5822
+        ],
+        "project_license": "LGPL-2.0 and PatentConcern",
+        "type": "codec",
+        "categories": [
+            8,
+            102
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 549
+},
+{
+    "fields": {
+        "pkgname": "gstreamer1-plugins-base",
+        "type_id": "gstreamer-base",
+        "keywords": [
+            5823,
+            5824,
+            5825
+        ],
+        "project_license": "LGPL-2.1+",
+        "type": "codec",
+        "categories": [
+            8,
+            102
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 550
+},
+{
+    "fields": {
+        "pkgname": "gstreamer-plugins-espeak",
+        "type_id": "gstreamer-espeak",
+        "keywords": [
+            5826
+        ],
+        "project_license": "LGPL-2.1+",
+        "type": "codec",
+        "categories": [
+            8,
+            102
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 551
+},
+{
+    "fields": {
+        "pkgname": "gstreamer1-plugins-good",
+        "type_id": "gstreamer-good",
+        "keywords": [
+            827,
+            5827,
+            5828,
+            5829,
+            5830,
+            5831,
+            5832,
+            5833,
+            5834,
+            5835,
+            5836,
+            5837
+        ],
+        "project_license": "LGPL-2.1+",
+        "type": "codec",
+        "categories": [
+            8,
+            102
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 552
+},
+{
+    "fields": {
+        "pkgname": "gstreamer1-libav",
+        "type_id": "gstreamer-libav",
+        "keywords": [
+            5820,
+            5828,
+            5829,
+            5838,
+            5839,
+            5840,
+            5841,
+            5842,
+            5843,
+            5844
+        ],
+        "project_license": "LGPL-2.0",
+        "type": "codec",
+        "categories": [
+            8,
+            102
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 553
+},
+{
+    "fields": {
+        "pkgname": "gstreamer1-plugins-ugly",
+        "type_id": "gstreamer-ugly",
+        "keywords": [
+            5818,
+            5838,
+            5839,
+            5842,
+            5845,
+            5846,
+            5847,
+            5848,
+            5849,
+            5850
+        ],
+        "project_license": "LGPL-2.0 and PatentConcern",
+        "type": "codec",
+        "categories": [
+            8,
+            102
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 554
+},
+{
+    "fields": {
+        "pkgname": "gtg",
+        "type_id": "gtg.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            103
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 555
+},
+{
+    "fields": {
+        "pkgname": "gthumb",
+        "type_id": "gthumb.desktop",
+        "keywords": [
+            878,
+            1395,
+            1396,
+            1408,
+            1447,
+            1454,
+            1482,
+            1505,
+            1528,
+            1531,
+            1628,
+            1698,
+            1699,
+            2356,
+            2366,
+            3145,
+            5851,
+            5852,
+            5853,
+            5854,
+            5855,
+            5856,
+            5857,
+            5858,
+            5859,
+            5860,
+            5861,
+            5862
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26,
+            71,
+            75,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 556
+},
+{
+    "fields": {
+        "pkgname": "gtimelog",
+        "type_id": "gtimelog.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 557
+},
+{
+    "fields": {
+        "pkgname": "gtk-gnutella",
+        "type_id": "gtk-gnutella.desktop",
+        "keywords": [
+            5863
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            76,
+            77
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 558
+},
+{
+    "fields": {
+        "pkgname": "gtk-v4l",
+        "type_id": "gtk-v4l.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            7,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 559
+},
+{
+    "fields": {
+        "pkgname": "gtkpod",
+        "type_id": "gtkpod.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 560
+},
+{
+    "fields": {
+        "pkgname": "gtkterm",
+        "type_id": "gtkterm.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 561
+},
+{
+    "fields": {
+        "pkgname": "gtkwave",
+        "type_id": "gtkwave.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            16,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 562
+},
+{
+    "fields": {
+        "pkgname": "gtranslator",
+        "type_id": "gtranslator.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            104
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 563
+},
+{
+    "fields": {
+        "pkgname": "guake",
+        "type_id": "guake.desktop",
+        "keywords": [
+            5864,
+            5865
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            5,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 564
+},
+{
+    "fields": {
+        "pkgname": "guayadeque",
+        "type_id": "guayadeque.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND BSD-3-Clause AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 565
+},
+{
+    "fields": {
+        "pkgname": "gucharmap",
+        "type_id": "gucharmap.desktop",
+        "keywords": [
+            2307,
+            5161,
+            5256,
+            5266,
+            5298,
+            5363,
+            5378,
+            5384,
+            5394,
+            5866,
+            5867,
+            5868,
+            5869,
+            5870,
+            5871,
+            5872,
+            5873,
+            5874,
+            5875,
+            5876,
+            5877,
+            5878,
+            5879,
+            5880,
+            5881,
+            5882,
+            5883,
+            5884,
+            5885,
+            5886,
+            5887,
+            5888,
+            5889,
+            5890,
+            5891,
+            5892,
+            5893,
+            5894,
+            5895,
+            5896,
+            5897,
+            5898,
+            5899,
+            5900,
+            5901,
+            5902,
+            5903,
+            5904,
+            5905,
+            5906,
+            5907,
+            5908,
+            5909,
+            5910,
+            5911,
+            5912,
+            5913,
+            5914,
+            5915,
+            5916,
+            5917,
+            5918,
+            5919,
+            5920,
+            5921,
+            5922,
+            5923,
+            5924,
+            5925,
+            5926,
+            5927,
+            5928,
+            5929,
+            5930,
+            5931,
+            5932,
+            5933,
+            5934,
+            5935,
+            5936,
+            5937,
+            5938,
+            5939,
+            5940,
+            5941,
+            5942,
+            5943,
+            5944,
+            5945,
+            5946,
+            5947,
+            5948,
+            5949,
+            5950,
+            5951,
+            5952,
+            5953,
+            5954,
+            5955,
+            5956,
+            5957,
+            5958,
+            5959,
+            5960,
+            5961,
+            5962,
+            5963,
+            5964,
+            5965,
+            5966,
+            5967,
+            5968,
+            5969,
+            5970,
+            5971,
+            5972,
+            5973,
+            5974,
+            5975,
+            5976,
+            5977,
+            5978,
+            5979,
+            5980,
+            5981,
+            5982,
+            5983,
+            5984,
+            5985,
+            5986,
+            5987
+        ],
+        "project_license": "GPL-3.0+ AND GFDL-1.3 AND MIT",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 566
+},
+{
+    "fields": {
+        "pkgname": "guitone",
+        "type_id": "guitone.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 567
+},
+{
+    "fields": {
+        "pkgname": "gummi",
+        "type_id": "gummi.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            13,
+            31
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 568
+},
+{
+    "fields": {
+        "pkgname": "vim-X11",
+        "type_id": "gvim.desktop",
+        "keywords": [],
+        "project_license": "Vim",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 569
+},
+{
+    "fields": {
+        "pkgname": "gweled",
+        "type_id": "gweled.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 570
+},
+{
+    "fields": {
+        "pkgname": "gwenview",
+        "type_id": "gwenview.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26,
+            75
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 571
+},
+{
+    "fields": {
+        "pkgname": "gwget",
+        "type_id": "gwget.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            76
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 572
+},
+{
+    "fields": {
+        "pkgname": "why-gwhy",
+        "type_id": "gwhy.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.0",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 573
+},
+{
+    "fields": {
+        "pkgname": "gwibber",
+        "type_id": "gwibber.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 574
+},
+{
+    "fields": {
+        "pkgname": "gxneur",
+        "type_id": "gxneur.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 575
+},
+{
+    "fields": {
+        "pkgname": "hamster-time-tracker",
+        "type_id": "hamster-time-tracker.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 576
+},
+{
+    "fields": {
+        "pkgname": "hanazono-fonts",
+        "type_id": "hanazono",
+        "keywords": [],
+        "project_license": "Copyright only OR OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 577
+},
+{
+    "fields": {
+        "pkgname": "ibus-handwrite-ja",
+        "type_id": "handwrite-jp.xml",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 578
+},
+{
+    "fields": {
+        "pkgname": "ibus-handwrite-zh_CN",
+        "type_id": "handwrite-zh.xml",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 579
+},
+{
+    "fields": {
+        "pkgname": "ibus-hangul",
+        "type_id": "hangul.xml",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 580
+},
+{
+    "fields": {
+        "pkgname": "harmonyseq",
+        "type_id": "harmonyseq.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            78,
+            105
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 581
+},
+{
+    "fields": {
+        "pkgname": "hatari",
+        "type_id": "hatari.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            29
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 582
+},
+{
+    "fields": {
+        "pkgname": "haxima",
+        "type_id": "haxima.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            74
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 583
+},
+{
+    "fields": {
+        "pkgname": "hdfview",
+        "type_id": "hdfview.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            19,
+            20,
+            21,
+            28
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 584
+},
+{
+    "fields": {
+        "pkgname": "heimdall-frontend",
+        "type_id": "heimdall.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 585
+},
+{
+    "fields": {
+        "pkgname": "hex-a-hop",
+        "type_id": "hex-a-hop.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44,
+            106
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 586
+},
+{
+    "fields": {
+        "pkgname": "hexalate",
+        "type_id": "hexalate.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 587
+},
+{
+    "fields": {
+        "pkgname": "hexchat",
+        "type_id": "hexchat.desktop",
+        "keywords": [
+            1201,
+            1202,
+            1238,
+            1345,
+            5988,
+            5989,
+            5990,
+            5991,
+            5992,
+            5993,
+            5994,
+            5995
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            70
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 588
+},
+{
+    "fields": {
+        "pkgname": "hitori",
+        "type_id": "hitori.desktop",
+        "keywords": [
+            198,
+            200,
+            1652,
+            2167,
+            2168,
+            2176,
+            2177,
+            2179,
+            2180,
+            2185,
+            2186,
+            2189,
+            2190,
+            2195,
+            2196,
+            2200,
+            2201,
+            2203,
+            2204,
+            2207,
+            2208,
+            2210,
+            2211,
+            2212,
+            2213,
+            2214,
+            2220,
+            2221,
+            2229,
+            2230,
+            2231,
+            2233,
+            2235,
+            2236,
+            2237,
+            2242,
+            2243,
+            2253,
+            2254,
+            2262,
+            2263,
+            2264,
+            2265,
+            2267,
+            2268,
+            2269,
+            2272,
+            2273,
+            2275,
+            2276,
+            2278,
+            2279,
+            2281,
+            2282,
+            2287,
+            2288,
+            2293,
+            2303,
+            2304,
+            2678,
+            2679,
+            2681,
+            2682,
+            2683,
+            2684,
+            3780,
+            3786,
+            3789,
+            3794,
+            3798,
+            3802,
+            3805,
+            3808,
+            3816,
+            3822,
+            3823,
+            3826,
+            3830,
+            3834,
+            3838,
+            3840,
+            3844,
+            3850,
+            3855,
+            4089,
+            4092,
+            5996,
+            5997,
+            5998,
+            5999,
+            6000,
+            6001,
+            6002,
+            6003,
+            6004,
+            6005,
+            6006,
+            6007,
+            6008,
+            6009,
+            6010,
+            6011,
+            6012,
+            6013,
+            6014,
+            6015,
+            6016,
+            6017,
+            6018,
+            6019,
+            6020,
+            6021,
+            6022,
+            6023,
+            6024,
+            6025,
+            6026,
+            6027,
+            6028,
+            6029,
+            6030,
+            6031,
+            6032,
+            6033,
+            6034,
+            6035,
+            6036,
+            6037
+        ],
+        "project_license": "GPL-3.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 589
+},
+{
+    "fields": {
+        "pkgname": "homebank",
+        "type_id": "homebank.desktop",
+        "keywords": [
+            6038,
+            6039,
+            6040,
+            6041,
+            6042
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            79
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 590
+},
+{
+    "fields": {
+        "pkgname": "htmldoc",
+        "type_id": "htmldoc.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 591
+},
+{
+    "fields": {
+        "pkgname": "hugin",
+        "type_id": "hugin.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 592
+},
+{
+    "fields": {
+        "pkgname": "alsa-tools",
+        "type_id": "hwmixvolume.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 593
+},
+{
+    "fields": {
+        "pkgname": "hydrogen",
+        "type_id": "hydrogen.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            56,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 594
+},
+{
+    "fields": {
+        "pkgname": "iagno",
+        "type_id": "iagno.desktop",
+        "keywords": [
+            2183,
+            3790,
+            6043,
+            6044,
+            6045,
+            6046,
+            6047,
+            6048,
+            6049,
+            6050,
+            6051,
+            6052,
+            6053,
+            6054,
+            6055,
+            6056,
+            6057,
+            6058,
+            6059,
+            6060,
+            6061,
+            6062,
+            6063,
+            6064,
+            6065,
+            6066,
+            6067,
+            6068,
+            6069,
+            6070,
+            6071,
+            6072,
+            6073,
+            6074,
+            6075,
+            6076
+        ],
+        "project_license": "GPL-3.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            60
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 595
+},
+{
+    "fields": {
+        "pkgname": "iapetal",
+        "type_id": "iapetal.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 596
+},
+{
+    "fields": {
+        "pkgname": "icedtea-web",
+        "type_id": "icedtea-web",
+        "keywords": [],
+        "project_license": "LGPL-2.1+ AND GPL-2.0-with-font-exception",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 597
+},
+{
+    "fields": {
+        "pkgname": "idjc",
+        "type_id": "idjc.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 598
+},
+{
+    "fields": {
+        "pkgname": "python3-iep",
+        "type_id": "iep.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 599
+},
+{
+    "fields": {
+        "pkgname": "ignuit",
+        "type_id": "ignuit.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            19,
+            46
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 600
+},
+{
+    "fields": {
+        "pkgname": "mono-tools-ilcontrast",
+        "type_id": "ilcontrast.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            11,
+            66
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 601
+},
+{
+    "fields": {
+        "pkgname": "imagej",
+        "type_id": "imagej.desktop",
+        "keywords": [],
+        "project_license": "Public Domain",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 602
+},
+{
+    "fields": {
+        "pkgname": "impallari-lobster-fonts",
+        "type_id": "impallari-lobster",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 603
+},
+{
+    "fields": {
+        "pkgname": "inkboy-fonts",
+        "type_id": "inkboy",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 604
+},
+{
+    "fields": {
+        "pkgname": "inkscape",
+        "type_id": "inkscape.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            88
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 605
+},
+{
+    "fields": {
+        "pkgname": "ibus-input-pad",
+        "type_id": "input-pad.xml",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 606
+},
+{
+    "fields": {
+        "pkgname": "insight",
+        "type_id": "insight.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND GPL-3.0+ AND GPL-2.0+ AND GPL-2.0-with-font-exception AND GPL-1.0+ AND LGPL-2.1+ AND BSD-3-Clause AND Public Domain AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            11,
+            42
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 607
+},
+{
+    "fields": {
+        "pkgname": "iok",
+        "type_id": "iok.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            38
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 608
+},
+{
+    "fields": {
+        "pkgname": "ipa-ex-gothic-fonts",
+        "type_id": "ipa-ex-gothic",
+        "keywords": [],
+        "project_license": "IPA",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 609
+},
+{
+    "fields": {
+        "pkgname": "ipa-ex-mincho-fonts",
+        "type_id": "ipa-ex-mincho",
+        "keywords": [],
+        "project_license": "IPA",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 610
+},
+{
+    "fields": {
+        "pkgname": "ipa-gothic-fonts",
+        "type_id": "ipa-gothic",
+        "keywords": [],
+        "project_license": "IPA",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 611
+},
+{
+    "fields": {
+        "pkgname": "ipa-mincho-fonts",
+        "type_id": "ipa-mincho",
+        "keywords": [],
+        "project_license": "IPA",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 612
+},
+{
+    "fields": {
+        "pkgname": "ibus-table-latin",
+        "type_id": "ipa-x-sampa.db",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 613
+},
+{
+    "fields": {
+        "pkgname": "ircp-tray",
+        "type_id": "ircp-tray.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 614
+},
+{
+    "fields": {
+        "pkgname": "isomaster",
+        "type_id": "isomaster.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            56,
+            64,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 615
+},
+{
+    "fields": {
+        "pkgname": "jaaa",
+        "type_id": "jaaa.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 616
+},
+{
+    "fields": {
+        "pkgname": "jack_capture",
+        "type_id": "jack_capture.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND BSD-3-Clause AND LGPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            57,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 617
+},
+{
+    "fields": {
+        "pkgname": "jam-control",
+        "type_id": "jam-control.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 618
+},
+{
+    "fields": {
+        "pkgname": "jamin",
+        "type_id": "jamin.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 619
+},
+{
+    "fields": {
+        "pkgname": "japa",
+        "type_id": "japa.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 620
+},
+{
+    "fields": {
+        "pkgname": "java-1.8.0-openjdk-devel-debug",
+        "type_id": "java-1.8.0-openjdk-1.8.0.45-36.b13.fc22.x86_64-debug-jconsole-debug.desktop",
+        "keywords": [],
+        "project_license": "Apache-1.1 AND Apache-2.0 AND GPL-1.0+ AND GPL-2.0 AND GPL-2.0-with-font-exception AND LGPL-2.1+ AND LGPL-2.1 AND MPL-1.0 AND MPL-1.1 AND Public Domain AND W3C",
+        "type": "desktop",
+        "categories": [
+            11,
+            49,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 621
+},
+{
+    "fields": {
+        "pkgname": "java-1.8.0-openjdk-devel",
+        "type_id": "java-1.8.0-openjdk-1.8.0.45-36.b13.fc22.x86_64-jconsole.desktop",
+        "keywords": [],
+        "project_license": "Apache-1.1 AND Apache-2.0 AND GPL-1.0+ AND GPL-2.0 AND GPL-2.0-with-font-exception AND LGPL-2.1+ AND LGPL-2.1 AND MPL-1.0 AND MPL-1.1 AND Public Domain AND W3C",
+        "type": "desktop",
+        "categories": [
+            11,
+            49,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 622
+},
+{
+    "fields": {
+        "pkgname": "java-wakeonlan",
+        "type_id": "java-wakeonlan.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 623
+},
+{
+    "fields": {
+        "pkgname": "jaxodraw",
+        "type_id": "jaxodraw.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            20,
+            21,
+            26,
+            84,
+            88
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 624
+},
+{
+    "fields": {
+        "pkgname": "jd",
+        "type_id": "jd.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 625
+},
+{
+    "fields": {
+        "pkgname": "why-jessie",
+        "type_id": "jessie.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.0",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 626
+},
+{
+    "fields": {
+        "pkgname": "jflex",
+        "type_id": "jflex.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 627
+},
+{
+    "fields": {
+        "pkgname": "jmol",
+        "type_id": "jmol.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+ AND IJG AND BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            18,
+            19,
+            20,
+            21,
+            28
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 628
+},
+{
+    "fields": {
+        "pkgname": "jomolhari-fonts",
+        "type_id": "jomolhari",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 629
+},
+{
+    "fields": {
+        "pkgname": "josm",
+        "type_id": "josm.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            87,
+            100
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 630
+},
+{
+    "fields": {
+        "pkgname": "jpanoramamaker",
+        "type_id": "jpanoramamaker.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 631
+},
+{
+    "fields": {
+        "pkgname": "juffed",
+        "type_id": "juffed.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 632
+},
+{
+    "fields": {
+        "pkgname": "juk",
+        "type_id": "juk.desktop",
+        "keywords": [],
+        "project_license": "(GPL-2.0 OR GPL-3.0) AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 633
+},
+{
+    "fields": {
+        "pkgname": "julia",
+        "type_id": "julia.desktop",
+        "keywords": [],
+        "project_license": "MIT AND LGPL-2.1+ AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            21,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 634
+},
+{
+    "fields": {
+        "pkgname": "k3b",
+        "type_id": "k3b.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            7,
+            64,
+            99
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 635
+},
+{
+    "fields": {
+        "pkgname": "k3d",
+        "type_id": "k3d.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 636
+},
+{
+    "fields": {
+        "pkgname": "kacst-art-fonts",
+        "type_id": "kacst-art",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 637
+},
+{
+    "fields": {
+        "pkgname": "kajongg",
+        "type_id": "kajongg.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            60
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 638
+},
+{
+    "fields": {
+        "pkgname": "kalapi-fonts",
+        "type_id": "kalapi",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 639
+},
+{
+    "fields": {
+        "pkgname": "kalzium",
+        "type_id": "kalzium.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            18,
+            19,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 640
+},
+{
+    "fields": {
+        "pkgname": "kamoso",
+        "type_id": "kamoso.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 641
+},
+{
+    "fields": {
+        "pkgname": "kanjistrokeorders-fonts",
+        "type_id": "kanjistrokeorders",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 642
+},
+{
+    "fields": {
+        "pkgname": "kanyremote",
+        "type_id": "kanyremote.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 643
+},
+{
+    "fields": {
+        "pkgname": "kapow",
+        "type_id": "kapow.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            67
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 644
+},
+{
+    "fields": {
+        "pkgname": "kapptemplate",
+        "type_id": "kapptemplate.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 645
+},
+{
+    "fields": {
+        "pkgname": "calligra-karbon",
+        "type_id": "karbon.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            13,
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 646
+},
+{
+    "fields": {
+        "pkgname": "kbibtex",
+        "type_id": "kbibtex.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            19,
+            21,
+            40,
+            55
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 647
+},
+{
+    "fields": {
+        "pkgname": "kcachegrind",
+        "type_id": "kcachegrind.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 648
+},
+{
+    "fields": {
+        "pkgname": "kchmviewer-qt",
+        "type_id": "kchmviewer-qt.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            14
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 649
+},
+{
+    "fields": {
+        "pkgname": "kchmviewer",
+        "type_id": "kchmviewer.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            14
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 650
+},
+{
+    "fields": {
+        "pkgname": "kdbg",
+        "type_id": "kdbg.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            42
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 651
+},
+{
+    "fields": {
+        "pkgname": "kde-connect",
+        "type_id": "kdeconnect-non-plasma.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 652
+},
+{
+    "fields": {
+        "pkgname": "kdesvn",
+        "type_id": "kdesvn.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            94
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 653
+},
+{
+    "fields": {
+        "pkgname": "kdocker",
+        "type_id": "kdocker.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 654
+},
+{
+    "fields": {
+        "pkgname": "keepass",
+        "type_id": "keepass.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 655
+},
+{
+    "fields": {
+        "pkgname": "kernelshark",
+        "type_id": "kernelshark.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            11,
+            66
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 656
+},
+{
+    "fields": {
+        "pkgname": "calligra-kexi",
+        "type_id": "kexi.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 657
+},
+{
+    "fields": {
+        "pkgname": "kfind",
+        "type_id": "kfind.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 658
+},
+{
+    "fields": {
+        "pkgname": "kgpg",
+        "type_id": "kgpg.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 659
+},
+{
+    "fields": {
+        "pkgname": "khmeros-base-fonts",
+        "type_id": "khmeros-base",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 660
+},
+{
+    "fields": {
+        "pkgname": "kicad",
+        "type_id": "kicad.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            16
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 661
+},
+{
+    "fields": {
+        "pkgname": "kid3-qt",
+        "type_id": "kid3-qt.desktop",
+        "keywords": [
+            339,
+            796,
+            1091,
+            1093,
+            6077,
+            6078,
+            6079
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            56
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 662
+},
+{
+    "fields": {
+        "pkgname": "kid3",
+        "type_id": "kid3.desktop",
+        "keywords": [
+            339,
+            796,
+            1091,
+            1093,
+            6077,
+            6078,
+            6079
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            56
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 663
+},
+{
+    "fields": {
+        "pkgname": "kig",
+        "type_id": "kig.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 664
+},
+{
+    "fields": {
+        "pkgname": "kile",
+        "type_id": "kile.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            31
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 665
+},
+{
+    "fields": {
+        "pkgname": "kismon",
+        "type_id": "kismon.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 666
+},
+{
+    "fields": {
+        "pkgname": "ibus-kkc",
+        "type_id": "kkc.xml",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 667
+},
+{
+    "fields": {
+        "pkgname": "klatexformula",
+        "type_id": "klatexformula.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 668
+},
+{
+    "fields": {
+        "pkgname": "klog",
+        "type_id": "klog.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 669
+},
+{
+    "fields": {
+        "pkgname": "kmess",
+        "type_id": "kmess.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            82
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 670
+},
+{
+    "fields": {
+        "pkgname": "kmetronome",
+        "type_id": "kmetronome.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            19,
+            57,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 671
+},
+{
+    "fields": {
+        "pkgname": "kmldonkey",
+        "type_id": "kmldonkey.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            76
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 672
+},
+{
+    "fields": {
+        "pkgname": "kmplayer",
+        "type_id": "kmplayer.desktop",
+        "keywords": [],
+        "project_license": "GFDL-1.3 AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 673
+},
+{
+    "fields": {
+        "pkgname": "kmymoney",
+        "type_id": "kmymoney.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            79
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 674
+},
+{
+    "fields": {
+        "pkgname": "knapsen",
+        "type_id": "knapsen.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            107
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 675
+},
+{
+    "fields": {
+        "pkgname": "kolourpaint",
+        "type_id": "kolourpaint.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            26,
+            71,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 676
+},
+{
+    "fields": {
+        "pkgname": "kopete",
+        "type_id": "kopete.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            23,
+            82
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 677
+},
+{
+    "fields": {
+        "pkgname": "korganizer",
+        "type_id": "korganizer.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            13,
+            67
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 678
+},
+{
+    "fields": {
+        "pkgname": "kradio4",
+        "type_id": "kradio4.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 679
+},
+{
+    "fields": {
+        "pkgname": "krb5-auth-dialog",
+        "type_id": "krb5-auth-dialog.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 680
+},
+{
+    "fields": {
+        "pkgname": "krecipes",
+        "type_id": "krecipes.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            40
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 681
+},
+{
+    "fields": {
+        "pkgname": "krename",
+        "type_id": "krename.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 682
+},
+{
+    "fields": {
+        "pkgname": "calligra-krita",
+        "type_id": "krita.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 683
+},
+{
+    "fields": {
+        "pkgname": "krop",
+        "type_id": "krop.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 684
+},
+{
+    "fields": {
+        "pkgname": "krusader",
+        "type_id": "krusader.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            3,
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 685
+},
+{
+    "fields": {
+        "pkgname": "kshutdown",
+        "type_id": "kshutdown.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 686
+},
+{
+    "fields": {
+        "pkgname": "ksudoku",
+        "type_id": "ksudoku.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 687
+},
+{
+    "fields": {
+        "pkgname": "ktikz",
+        "type_id": "ktikz.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 688
+},
+{
+    "fields": {
+        "pkgname": "kmail",
+        "type_id": "ktnef.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            13,
+            22,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 689
+},
+{
+    "fields": {
+        "pkgname": "ktorrent",
+        "type_id": "ktorrent.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            76,
+            77
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 690
+},
+{
+    "fields": {
+        "pkgname": "ktouch",
+        "type_id": "ktouch.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 691
+},
+{
+    "fields": {
+        "pkgname": "kubrick",
+        "type_id": "kubrick.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 692
+},
+{
+    "fields": {
+        "pkgname": "kurdit-unikurd-web-fonts",
+        "type_id": "kurdit-unikurd-web",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 693
+},
+{
+    "fields": {
+        "pkgname": "kvirc",
+        "type_id": "kvirc.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "desktop",
+        "categories": [
+            23,
+            70
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 694
+},
+{
+    "fields": {
+        "pkgname": "l3afpad",
+        "type_id": "l3afpad.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 695
+},
+{
+    "fields": {
+        "pkgname": "labyrinth",
+        "type_id": "labyrinth.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 696
+},
+{
+    "fields": {
+        "pkgname": "latexila",
+        "type_id": "latexila.desktop",
+        "keywords": [
+            796,
+            6080,
+            6081,
+            6082,
+            6083,
+            6084,
+            6085,
+            6086,
+            6087,
+            6088,
+            6089,
+            6090,
+            6091,
+            6092,
+            6093,
+            6094,
+            6095,
+            6096,
+            6097,
+            6098,
+            6099,
+            6100,
+            6101,
+            6102,
+            6103,
+            6104,
+            6105,
+            6106,
+            6107,
+            6108,
+            6109,
+            6110,
+            6111,
+            6112,
+            6113,
+            6114,
+            6115,
+            6116
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            31,
+            37
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 697
+},
+{
+    "fields": {
+        "pkgname": "launchy",
+        "type_id": "launchy.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 698
+},
+{
+    "fields": {
+        "pkgname": "lazarus",
+        "type_id": "lazarus.desktop",
+        "keywords": [
+            131,
+            796,
+            6117,
+            6118,
+            6119,
+            6120,
+            6121
+        ],
+        "project_license": "GPL-2.0+ AND MPL-1.1 AND LGPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            45,
+            90
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 699
+},
+{
+    "fields": {
+        "pkgname": "lbrickbuster2",
+        "type_id": "lbrickbuster2.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            10,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 700
+},
+{
+    "fields": {
+        "pkgname": "leafpad",
+        "type_id": "leafpad.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 701
+},
+{
+    "fields": {
+        "pkgname": "lekhonee-gnome",
+        "type_id": "lekhonee-gnome.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 702
+},
+{
+    "fields": {
+        "pkgname": "leksah",
+        "type_id": "leksah.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 703
+},
+{
+    "fields": {
+        "pkgname": "levien-inconsolata-fonts",
+        "type_id": "levien-inconsolata",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 704
+},
+{
+    "fields": {
+        "pkgname": "levien-museum-fonts",
+        "type_id": "levien-museum",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 705
+},
+{
+    "fields": {
+        "pkgname": "linux-libertine-fonts",
+        "type_id": "libertine",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception OR OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 706
+},
+{
+    "fields": {
+        "pkgname": "google-talkplugin",
+        "type_id": "libnpgoogletalk.so",
+        "keywords": [
+            1127,
+            1599
+        ],
+        "project_license": null,
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 707
+},
+{
+    "fields": {
+        "pkgname": "ibus-libpinyin",
+        "type_id": "libpinyin.xml",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 708
+},
+{
+    "fields": {
+        "pkgname": "librecad",
+        "type_id": "librecad.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 709
+},
+{
+    "fields": {
+        "pkgname": "libreoffice-base",
+        "type_id": "libreoffice-base.desktop",
+        "keywords": [
+            6122,
+            6123
+        ],
+        "project_license": "(MPL-1.1 OR LGPL-3.0+) AND LGPL-3.0 AND LGPL-2.1+ AND BSD-3-Clause AND (MPL-1.1 OR GPL-2.0 OR LGPL-2.1 OR NPL-1.1) AND Public Domain AND Apache-2.0 AND Artistic-1.0 AND MPL-2.0 AND CC0-1.0",
+        "type": "desktop",
+        "categories": [
+            13,
+            40
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 710
+},
+{
+    "fields": {
+        "pkgname": "libreoffice-calc",
+        "type_id": "libreoffice-calc.desktop",
+        "keywords": [
+            6124,
+            6125,
+            6126,
+            6127,
+            6128,
+            6129,
+            6130,
+            6131,
+            6132,
+            6133
+        ],
+        "project_license": "(MPL-1.1 OR LGPL-3.0+) AND LGPL-3.0 AND LGPL-2.1+ AND BSD-3-Clause AND (MPL-1.1 OR GPL-2.0 OR LGPL-2.1 OR NPL-1.1) AND Public Domain AND Apache-2.0 AND Artistic-1.0 AND MPL-2.0 AND CC0-1.0",
+        "type": "desktop",
+        "categories": [
+            13,
+            98
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 711
+},
+{
+    "fields": {
+        "pkgname": "libreoffice-draw",
+        "type_id": "libreoffice-draw.desktop",
+        "keywords": [
+            3656,
+            6134,
+            6135,
+            6136,
+            6137,
+            6138,
+            6139,
+            6140,
+            6141,
+            6142
+        ],
+        "project_license": "(MPL-1.1 OR LGPL-3.0+) AND LGPL-3.0 AND LGPL-2.1+ AND BSD-3-Clause AND (MPL-1.1 OR GPL-2.0 OR LGPL-2.1 OR NPL-1.1) AND Public Domain AND Apache-2.0 AND Artistic-1.0 AND MPL-2.0 AND CC0-1.0",
+        "type": "desktop",
+        "categories": [
+            13,
+            26,
+            84,
+            88,
+            108
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 712
+},
+{
+    "fields": {
+        "pkgname": "libreoffice-impress",
+        "type_id": "libreoffice-impress.desktop",
+        "keywords": [
+            1370,
+            6127,
+            6143,
+            6144,
+            6145,
+            6146,
+            6147,
+            6148,
+            6149
+        ],
+        "project_license": "(MPL-1.1 OR LGPL-3.0+) AND LGPL-3.0 AND LGPL-2.1+ AND BSD-3-Clause AND (MPL-1.1 OR GPL-2.0 OR LGPL-2.1 OR NPL-1.1) AND Public Domain AND Apache-2.0 AND Artistic-1.0 AND MPL-2.0 AND CC0-1.0",
+        "type": "desktop",
+        "categories": [
+            13,
+            109
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 713
+},
+{
+    "fields": {
+        "pkgname": "libreoffice-writer",
+        "type_id": "libreoffice-writer.desktop",
+        "keywords": [
+            6127,
+            6150,
+            6151,
+            6152,
+            6153,
+            6154,
+            6155,
+            6156,
+            6157,
+            6158,
+            6159,
+            6160,
+            6161,
+            6162
+        ],
+        "project_license": "(MPL-1.1 OR LGPL-3.0+) AND LGPL-3.0 AND LGPL-2.1+ AND BSD-3-Clause AND (MPL-1.1 OR GPL-2.0 OR LGPL-2.1 OR NPL-1.1) AND Public Domain AND Apache-2.0 AND Artistic-1.0 AND MPL-2.0 AND CC0-1.0",
+        "type": "desktop",
+        "categories": [
+            13,
+            37
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 714
+},
+{
+    "fields": {
+        "pkgname": "ibus-libzhuyin",
+        "type_id": "libzhuyin.xml",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 715
+},
+{
+    "fields": {
+        "pkgname": "lifeograph",
+        "type_id": "lifeograph.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 716
+},
+{
+    "fields": {
+        "pkgname": "liferea",
+        "type_id": "liferea.desktop",
+        "keywords": [
+            1594,
+            6163,
+            6164,
+            6165,
+            6166,
+            6167,
+            6168,
+            6169,
+            6170,
+            6171,
+            6172,
+            6173,
+            6174,
+            6175,
+            6176,
+            6177
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            24
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 717
+},
+{
+    "fields": {
+        "pkgname": "lightsoff",
+        "type_id": "lightsoff.desktop",
+        "keywords": [
+            198,
+            200,
+            2163,
+            2164,
+            2165,
+            2167,
+            2168,
+            2171,
+            2172,
+            2174,
+            2175,
+            2176,
+            2177,
+            2179,
+            2180,
+            2182,
+            2183,
+            2185,
+            2186,
+            2189,
+            2190,
+            2191,
+            2192,
+            2195,
+            2196,
+            2198,
+            2199,
+            2200,
+            2201,
+            2203,
+            2204,
+            2207,
+            2208,
+            2210,
+            2211,
+            2212,
+            2213,
+            2214,
+            2216,
+            2217,
+            2219,
+            2220,
+            2221,
+            2224,
+            2226,
+            2227,
+            2228,
+            2229,
+            2230,
+            2231,
+            2233,
+            2235,
+            2236,
+            2237,
+            2239,
+            2242,
+            2243,
+            2252,
+            2253,
+            2254,
+            2255,
+            2259,
+            2260,
+            2262,
+            2263,
+            2264,
+            2265,
+            2267,
+            2268,
+            2269,
+            2272,
+            2273,
+            2275,
+            2276,
+            2278,
+            2279,
+            2281,
+            2282,
+            2284,
+            2286,
+            2287,
+            2288,
+            2290,
+            2292,
+            2293,
+            2296,
+            2298,
+            2300,
+            2301,
+            2303,
+            2304,
+            2350,
+            2678,
+            2679,
+            2680,
+            2681,
+            2682,
+            2683,
+            2684,
+            2953,
+            3748,
+            3768,
+            3769,
+            3771,
+            3772,
+            3773,
+            3774,
+            3781,
+            3782,
+            3783,
+            3784,
+            3785,
+            3786,
+            3787,
+            3788,
+            3790,
+            3791,
+            3792,
+            3794,
+            3795,
+            3796,
+            3799,
+            3800,
+            3802,
+            3803,
+            3804,
+            3805,
+            3806,
+            3807,
+            3808,
+            3810,
+            3812,
+            3813,
+            3814,
+            3816,
+            3817,
+            3820,
+            3821,
+            3822,
+            3823,
+            3824,
+            3825,
+            3826,
+            3829,
+            3830,
+            3832,
+            3833,
+            3834,
+            3835,
+            3837,
+            3838,
+            3839,
+            3840,
+            3841,
+            3846,
+            3848,
+            3849,
+            3850,
+            3851,
+            3852,
+            3853,
+            3854,
+            3855,
+            3856,
+            3859,
+            3860,
+            3861,
+            3862,
+            4129,
+            4145,
+            4159,
+            5102,
+            5105,
+            5106,
+            6001,
+            6012,
+            6013,
+            6031,
+            6035,
+            6178,
+            6179,
+            6180,
+            6181,
+            6182,
+            6183,
+            6184,
+            6185,
+            6186,
+            6187,
+            6188,
+            6189,
+            6190,
+            6191,
+            6192,
+            6193,
+            6194,
+            6195,
+            6196,
+            6197,
+            6198,
+            6199,
+            6200,
+            6201,
+            6202,
+            6203,
+            6204,
+            6205,
+            6206,
+            6207,
+            6208,
+            6209,
+            6210,
+            6211,
+            6212,
+            6213,
+            6214,
+            6215,
+            6216,
+            6217,
+            6218,
+            6219,
+            6220,
+            6221,
+            6222,
+            6223,
+            6224,
+            6225,
+            6226,
+            6227,
+            6228,
+            6229,
+            6230,
+            6231,
+            6232,
+            6233,
+            6234,
+            6235,
+            6236,
+            6237,
+            6238,
+            6239,
+            6240,
+            6241,
+            6242,
+            6243,
+            6244,
+            6245,
+            6246,
+            6247,
+            6248,
+            6249,
+            6250,
+            6251,
+            6252,
+            6253,
+            6254,
+            6255,
+            6256,
+            6257,
+            6258,
+            6259
+        ],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 718
+},
+{
+    "fields": {
+        "pkgname": "lilypond-century-schoolbook-l-fonts",
+        "type_id": "lilypond-century-schoolbook-l",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 719
+},
+{
+    "fields": {
+        "pkgname": "lilyterm",
+        "type_id": "lilyterm.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 720
+},
+{
+    "fields": {
+        "pkgname": "lincity-ng",
+        "type_id": "lincity-ng.desktop",
+        "keywords": [
+            195,
+            198,
+            2159,
+            2349,
+            6260,
+            6261,
+            6262,
+            6263
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            15
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 721
+},
+{
+    "fields": {
+        "pkgname": "lingot",
+        "type_id": "lingot.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 722
+},
+{
+    "fields": {
+        "pkgname": "linphone",
+        "type_id": "linphone.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            97
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 723
+},
+{
+    "fields": {
+        "pkgname": "linpsk",
+        "type_id": "linpsk.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 724
+},
+{
+    "fields": {
+        "pkgname": "liveusb-creator",
+        "type_id": "liveusb-creator.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 725
+},
+{
+    "fields": {
+        "pkgname": "lmms",
+        "type_id": "lmms.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-2.0 AND (GPL-2.0+ OR MIT) AND GPL-3.0+ AND MIT AND LGPL-2.1+ AND (LGPL-2.0+) AND Copyright only",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            78,
+            105
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 726
+},
+{
+    "fields": {
+        "pkgname": "lohit-assamese-fonts",
+        "type_id": "lohit-assamese",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 727
+},
+{
+    "fields": {
+        "pkgname": "lohit-bengali-fonts",
+        "type_id": "lohit-bengali",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 728
+},
+{
+    "fields": {
+        "pkgname": "lohit-devanagari-fonts",
+        "type_id": "lohit-devanagari",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 729
+},
+{
+    "fields": {
+        "pkgname": "lohit-gujarati-fonts",
+        "type_id": "lohit-gujarati",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 730
+},
+{
+    "fields": {
+        "pkgname": "lohit-gurmukhi-fonts",
+        "type_id": "lohit-gurmukhi",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 731
+},
+{
+    "fields": {
+        "pkgname": "lohit-kannada-fonts",
+        "type_id": "lohit-kannada",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 732
+},
+{
+    "fields": {
+        "pkgname": "lohit-malayalam-fonts",
+        "type_id": "lohit-malayalam",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 733
+},
+{
+    "fields": {
+        "pkgname": "lohit-marathi-fonts",
+        "type_id": "lohit-marathi",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 734
+},
+{
+    "fields": {
+        "pkgname": "lohit-nepali-fonts",
+        "type_id": "lohit-nepali",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 735
+},
+{
+    "fields": {
+        "pkgname": "lohit-odia-fonts",
+        "type_id": "lohit-odia",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 736
+},
+{
+    "fields": {
+        "pkgname": "lohit-tamil-fonts",
+        "type_id": "lohit-tamil",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 737
+},
+{
+    "fields": {
+        "pkgname": "lohit-telugu-fonts",
+        "type_id": "lohit-telugu",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 738
+},
+{
+    "fields": {
+        "pkgname": "lonote",
+        "type_id": "lonote.desktop",
+        "keywords": [],
+        "project_license": "Apache-2.0",
+        "type": "desktop",
+        "categories": [
+            11,
+            13,
+            103
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 739
+},
+{
+    "fields": {
+        "pkgname": "lookup",
+        "type_id": "lookup.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            4,
+            5,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 740
+},
+{
+    "fields": {
+        "pkgname": "loook",
+        "type_id": "loook.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 741
+},
+{
+    "fields": {
+        "pkgname": "lordsawar",
+        "type_id": "lordsawar.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 742
+},
+{
+    "fields": {
+        "pkgname": "lpf",
+        "type_id": "lpf-gui.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 743
+},
+{
+    "fields": {
+        "pkgname": "lpf",
+        "type_id": "lpf-notify.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 744
+},
+{
+    "fields": {
+        "pkgname": "lpf",
+        "type_id": "lpf.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 745
+},
+{
+    "fields": {
+        "pkgname": "lshw-gui",
+        "type_id": "lshw.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 746
+},
+{
+    "fields": {
+        "pkgname": "lttv",
+        "type_id": "lttv.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 747
+},
+{
+    "fields": {
+        "pkgname": "luckybackup",
+        "type_id": "luckybackup.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 748
+},
+{
+    "fields": {
+        "pkgname": "luma",
+        "type_id": "luma.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 749
+},
+{
+    "fields": {
+        "pkgname": "openav-luppp",
+        "type_id": "luppp.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 750
+},
+{
+    "fields": {
+        "pkgname": "LuxRender",
+        "type_id": "luxrender.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            26,
+            61
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 751
+},
+{
+    "fields": {
+        "pkgname": "lxmusic",
+        "type_id": "lxmusic.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 752
+},
+{
+    "fields": {
+        "pkgname": "lxtask",
+        "type_id": "lxtask.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 753
+},
+{
+    "fields": {
+        "pkgname": "lxterminal",
+        "type_id": "lxterminal.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 754
+},
+{
+    "fields": {
+        "pkgname": "lyx-common",
+        "type_id": "lyx.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            37
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 755
+},
+{
+    "fields": {
+        "pkgname": "ibus-m17n",
+        "type_id": "m17n.xml",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 756
+},
+{
+    "fields": {
+        "pkgname": "magic",
+        "type_id": "magic.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            16,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 757
+},
+{
+    "fields": {
+        "pkgname": "mailnag",
+        "type_id": "mailnag-config.desktop",
+        "keywords": [
+            595,
+            6264,
+            6265,
+            6266,
+            6267,
+            6268
+        ],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 758
+},
+{
+    "fields": {
+        "pkgname": "manaplus",
+        "type_id": "manaplus.desktop",
+        "keywords": [
+            198,
+            2348,
+            6269,
+            6270,
+            6271,
+            6272
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            73
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 759
+},
+{
+    "fields": {
+        "pkgname": "manchu-fonts",
+        "type_id": "manchu",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 760
+},
+{
+    "fields": {
+        "pkgname": "mandelbulber",
+        "type_id": "mandelbulber.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            21,
+            26,
+            27,
+            61
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 761
+},
+{
+    "fields": {
+        "pkgname": "marsshooter",
+        "type_id": "marsshooter.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND LGPL-2.1+ AND MPL-1.1",
+        "type": "desktop",
+        "categories": [
+            1
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 762
+},
+{
+    "fields": {
+        "pkgname": "massif-visualizer",
+        "type_id": "massif-visualizer.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 763
+},
+{
+    "fields": {
+        "pkgname": "mate-calc",
+        "type_id": "mate-calc.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            92
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 764
+},
+{
+    "fields": {
+        "pkgname": "mate-dictionary",
+        "type_id": "mate-dictionary.desktop",
+        "keywords": [
+            184,
+            6272,
+            6273,
+            6274,
+            6275,
+            6276,
+            6277
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            13,
+            59
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 765
+},
+{
+    "fields": {
+        "pkgname": "mate-disk-usage-analyzer",
+        "type_id": "mate-disk-usage-analyzer.desktop",
+        "keywords": [
+            184,
+            3106,
+            6278,
+            6279,
+            6280,
+            6281,
+            6282
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            4,
+            99
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 766
+},
+{
+    "fields": {
+        "pkgname": "mate-power-manager",
+        "type_id": "mate-power-statistics.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 767
+},
+{
+    "fields": {
+        "pkgname": "mate-screenshot",
+        "type_id": "mate-screenshot.desktop",
+        "keywords": [
+            184,
+            1584,
+            6283,
+            6284,
+            6285,
+            6286
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 768
+},
+{
+    "fields": {
+        "pkgname": "mate-search-tool",
+        "type_id": "mate-search-tool.desktop",
+        "keywords": [
+            184,
+            720,
+            6080,
+            6287,
+            6288,
+            6289,
+            6290,
+            6291,
+            6292,
+            6293,
+            6294
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            5,
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 769
+},
+{
+    "fields": {
+        "pkgname": "mate-system-monitor",
+        "type_id": "mate-system-monitor.desktop",
+        "keywords": [
+            184,
+            3993,
+            6295,
+            6296,
+            6297,
+            6298,
+            6299,
+            6300
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 770
+},
+{
+    "fields": {
+        "pkgname": "mate-terminal",
+        "type_id": "mate-terminal.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            5,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 771
+},
+{
+    "fields": {
+        "pkgname": "mathomatic",
+        "type_id": "mathomatic.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 772
+},
+{
+    "fields": {
+        "pkgname": "ibus-table-mathwriter",
+        "type_id": "mathwriter-ibus.db",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 773
+},
+{
+    "fields": {
+        "pkgname": "Mayavi",
+        "type_id": "mayavi2.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause AND EPL-1.0 AND LGPL-2.1+ AND LGPL-2.1 AND LGPL-3.0",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            28
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 774
+},
+{
+    "fields": {
+        "pkgname": "mcomix",
+        "type_id": "mcomix.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 775
+},
+{
+    "fields": {
+        "pkgname": "mcu8051ide",
+        "type_id": "mcu8051ide.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            16
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 776
+},
+{
+    "fields": {
+        "pkgname": "mediainfo-gui",
+        "type_id": "mediainfo-gui.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            7,
+            56
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 777
+},
+{
+    "fields": {
+        "pkgname": "megaglest",
+        "type_id": "megaglest.desktop",
+        "keywords": [
+            198,
+            2159,
+            6301
+        ],
+        "project_license": "GPL-3.0+ AND GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 778
+},
+{
+    "fields": {
+        "pkgname": "meld",
+        "type_id": "meld.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 779
+},
+{
+    "fields": {
+        "pkgname": "memaker",
+        "type_id": "memaker.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 780
+},
+{
+    "fields": {
+        "pkgname": "metamorphose2",
+        "type_id": "metamorphose2.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 781
+},
+{
+    "fields": {
+        "pkgname": "methane",
+        "type_id": "methane.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 782
+},
+{
+    "fields": {
+        "pkgname": "metromap",
+        "type_id": "metromap.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 783
+},
+{
+    "fields": {
+        "pkgname": "mgopen-canonica-fonts",
+        "type_id": "mgopen",
+        "keywords": [],
+        "project_license": "MgOpen",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 784
+},
+{
+    "fields": {
+        "pkgname": "midori",
+        "type_id": "midori.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            23,
+            52
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 785
+},
+{
+    "fields": {
+        "pkgname": "milkytracker",
+        "type_id": "milkytracker.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            105
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 786
+},
+{
+    "fields": {
+        "pkgname": "mindless",
+        "type_id": "mindless.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 787
+},
+{
+    "fields": {
+        "pkgname": "minetest",
+        "type_id": "minetest.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+ AND CC-BY-SA-3.0 AND MIT",
+        "type": "desktop",
+        "categories": [
+            1
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 788
+},
+{
+    "fields": {
+        "pkgname": "mirage",
+        "type_id": "mirage.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 789
+},
+{
+    "fields": {
+        "pkgname": "mldonkey-gui",
+        "type_id": "mldonkey.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            77
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 790
+},
+{
+    "fields": {
+        "pkgname": "mnemosyne",
+        "type_id": "mnemosyne.desktop",
+        "keywords": [],
+        "project_license": "AGPL-3.0",
+        "type": "desktop",
+        "categories": [
+            19,
+            46
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 791
+},
+{
+    "fields": {
+        "pkgname": "modem-manager-gui",
+        "type_id": "modem-manager-gui.desktop",
+        "keywords": [
+            721,
+            6302,
+            6303,
+            6304
+        ],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 792
+},
+{
+    "fields": {
+        "pkgname": "mona-sazanami-fonts",
+        "type_id": "monafont",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 793
+},
+{
+    "fields": {
+        "pkgname": "monobristol",
+        "type_id": "monoBristol.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 794
+},
+{
+    "fields": {
+        "pkgname": "monodevelop",
+        "type_id": "monodevelop.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 795
+},
+{
+    "fields": {
+        "pkgname": "mono-tools",
+        "type_id": "monodoc.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            11,
+            85
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 796
+},
+{
+    "fields": {
+        "pkgname": "moserial",
+        "type_id": "moserial.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            76,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 797
+},
+{
+    "fields": {
+        "pkgname": "motoya-lcedar-fonts",
+        "type_id": "motoya-lcedar",
+        "keywords": [],
+        "project_license": "Apache-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 798
+},
+{
+    "fields": {
+        "pkgname": "motoya-lmaru-fonts",
+        "type_id": "motoya-lmaru",
+        "keywords": [],
+        "project_license": "Apache-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 799
+},
+{
+    "fields": {
+        "pkgname": "mousepad",
+        "type_id": "mousepad.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 800
+},
+{
+    "fields": {
+        "pkgname": "moyogo-molengo-fonts",
+        "type_id": "moyogo-molengo",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 801
+},
+{
+    "fields": {
+        "pkgname": "ibus-mozc",
+        "type_id": "mozc.xml",
+        "keywords": [],
+        "project_license": "BSD-3-Clause AND Apache-2.0 AND UCD AND Public Domain AND mecab-ipadic",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 802
+},
+{
+    "fields": {
+        "pkgname": "mozilla-adblockplus",
+        "type_id": "mozilla-adblockplus",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 803
+},
+{
+    "fields": {
+        "pkgname": "mozilla-https-everywhere",
+        "type_id": "mozilla-https-everywhere",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 804
+},
+{
+    "fields": {
+        "pkgname": "thunderbird",
+        "type_id": "mozilla-thunderbird.desktop",
+        "keywords": [],
+        "project_license": "MPL-1.1 OR GPL-2.0+ OR LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            22,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 805
+},
+{
+    "fields": {
+        "pkgname": "mplus-1c-fonts",
+        "type_id": "mplus-1c",
+        "keywords": [],
+        "project_license": "mplus",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 806
+},
+{
+    "fields": {
+        "pkgname": "mplus-1m-fonts",
+        "type_id": "mplus-1m",
+        "keywords": [],
+        "project_license": "mplus",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 807
+},
+{
+    "fields": {
+        "pkgname": "mplus-1mn-fonts",
+        "type_id": "mplus-1mn",
+        "keywords": [],
+        "project_license": "mplus",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 808
+},
+{
+    "fields": {
+        "pkgname": "mplus-1p-fonts",
+        "type_id": "mplus-1p",
+        "keywords": [],
+        "project_license": "mplus",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 809
+},
+{
+    "fields": {
+        "pkgname": "mplus-2c-fonts",
+        "type_id": "mplus-2c",
+        "keywords": [],
+        "project_license": "mplus",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 810
+},
+{
+    "fields": {
+        "pkgname": "mplus-2m-fonts",
+        "type_id": "mplus-2m",
+        "keywords": [],
+        "project_license": "mplus",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 811
+},
+{
+    "fields": {
+        "pkgname": "mscore-fonts",
+        "type_id": "mscore",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception AND OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 812
+},
+{
+    "fields": {
+        "pkgname": "mscore",
+        "type_id": "mscore.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND LGPL-2.1+ AND LGPL-3.0 AND CC-BY-3.0 AND MIT AND OFL-1.1",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            57,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 813
+},
+{
+    "fields": {
+        "pkgname": "msimonson-anonymouspro-fonts",
+        "type_id": "msimonson-anonymouspro",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 814
+},
+{
+    "fields": {
+        "pkgname": "mtpaint",
+        "type_id": "mtpaint.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            71,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 815
+},
+{
+    "fields": {
+        "pkgname": "muse",
+        "type_id": "muse.desktop",
+        "keywords": [],
+        "project_license": "Public Domain AND GPL-2.0 AND GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            78,
+            105
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 816
+},
+{
+    "fields": {
+        "pkgname": "musique",
+        "type_id": "musique.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 817
+},
+{
+    "fields": {
+        "pkgname": "cave9-mutante-fonts",
+        "type_id": "mutante",
+        "keywords": [],
+        "project_license": "CC-BY-3.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 818
+},
+{
+    "fields": {
+        "pkgname": "myanmar3-unicode-fonts",
+        "type_id": "myanmar3-unicode",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 819
+},
+{
+    "fields": {
+        "pkgname": "mygui-tools",
+        "type_id": "mygui-layouteditor.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 820
+},
+{
+    "fields": {
+        "pkgname": "mypaint-data",
+        "type_id": "mypaint.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+ AND CC-BY-3.0",
+        "type": "desktop",
+        "categories": [
+            26,
+            71,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 821
+},
+{
+    "fields": {
+        "pkgname": "myrtle",
+        "type_id": "myrtle.desktop",
+        "keywords": [],
+        "project_license": "LGPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            27,
+            110
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 822
+},
+{
+    "fields": {
+        "pkgname": "naev",
+        "type_id": "naev.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            73
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 823
+},
+{
+    "fields": {
+        "pkgname": "nafees-tehreer-naskh-fonts",
+        "type_id": "nafees-tehreer-naskh",
+        "keywords": [],
+        "project_license": "Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 824
+},
+{
+    "fields": {
+        "pkgname": "nafees-web-naskh-fonts",
+        "type_id": "nafees-web-naskh",
+        "keywords": [],
+        "project_license": "Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 825
+},
+{
+    "fields": {
+        "pkgname": "nagstamon",
+        "type_id": "nagstamon.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 826
+},
+{
+    "fields": {
+        "pkgname": "naver-nanum-barun-gothic-fonts",
+        "type_id": "naver-nanum",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 827
+},
+{
+    "fields": {
+        "pkgname": "navilu-fonts",
+        "type_id": "navilu",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 828
+},
+{
+    "fields": {
+        "pkgname": "nemiver",
+        "type_id": "nemiver.desktop",
+        "keywords": [
+            844,
+            847,
+            854,
+            874,
+            2558,
+            2562,
+            4484,
+            6305,
+            6306,
+            6307,
+            6308,
+            6309,
+            6310,
+            6311,
+            6312,
+            6313,
+            6314,
+            6315,
+            6316,
+            6317,
+            6318,
+            6319,
+            6320,
+            6321,
+            6322,
+            6323,
+            6324,
+            6325,
+            6326,
+            6327,
+            6328,
+            6329,
+            6330,
+            6331,
+            6332,
+            6333,
+            6334,
+            6335,
+            6336,
+            6337,
+            6338,
+            6339,
+            6340,
+            6341,
+            6342,
+            6343,
+            6344,
+            6345,
+            6346,
+            6347,
+            6348,
+            6349,
+            6350,
+            6351,
+            6352,
+            6353,
+            6354,
+            6355,
+            6356
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            42
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 829
+},
+{
+    "fields": {
+        "pkgname": "nemo",
+        "type_id": "nemo.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            5,
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 830
+},
+{
+    "fields": {
+        "pkgname": "nested",
+        "type_id": "nested.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 831
+},
+{
+    "fields": {
+        "pkgname": "netactview",
+        "type_id": "netactview.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 832
+},
+{
+    "fields": {
+        "pkgname": "netgen-mesher-common",
+        "type_id": "netgen-mesher.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            21,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 833
+},
+{
+    "fields": {
+        "pkgname": "netpanzer",
+        "type_id": "netpanzer.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 834
+},
+{
+    "fields": {
+        "pkgname": "nfoview",
+        "type_id": "nfoview.desktop",
+        "keywords": [
+            904,
+            1857,
+            6357,
+            6358,
+            6359,
+            6360
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            47
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 835
+},
+{
+    "fields": {
+        "pkgname": "nip2",
+        "type_id": "nip2.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            71
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 836
+},
+{
+    "fields": {
+        "pkgname": "nntpgrab-gui",
+        "type_id": "nntpgrab.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 837
+},
+{
+    "fields": {
+        "pkgname": "nntpgrab-gui-qt",
+        "type_id": "nntpgrab_qt.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 838
+},
+{
+    "fields": {
+        "pkgname": "nntpgrab-server-gtk",
+        "type_id": "nntpgrab_server_gtk.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 839
+},
+{
+    "fields": {
+        "pkgname": "nntpgrab-server-qt",
+        "type_id": "nntpgrab_server_qt.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 840
+},
+{
+    "fields": {
+        "pkgname": "nomacs",
+        "type_id": "nomacs.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26,
+            71,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 841
+},
+{
+    "fields": {
+        "pkgname": "non-mixer",
+        "type_id": "non-mixer.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 842
+},
+{
+    "fields": {
+        "pkgname": "non-sequencer",
+        "type_id": "non-sequencer.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 843
+},
+{
+    "fields": {
+        "pkgname": "non-daw",
+        "type_id": "non-timeline.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 844
+},
+{
+    "fields": {
+        "pkgname": "novprog",
+        "type_id": "novprog.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 845
+},
+{
+    "fields": {
+        "pkgname": "ns-bola-fonts",
+        "type_id": "ns-bola",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 846
+},
+{
+    "fields": {
+        "pkgname": "ns-tiza-chalk-fonts",
+        "type_id": "ns-tiza-chalk",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 847
+},
+{
+    "fields": {
+        "pkgname": "numptyphysics",
+        "type_id": "numptyphysics.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 848
+},
+{
+    "fields": {
+        "pkgname": "nut-client",
+        "type_id": "nut-monitor.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 849
+},
+{
+    "fields": {
+        "pkgname": "nuvolaplayer",
+        "type_id": "nuvolaplayer.desktop",
+        "keywords": [],
+        "project_license": "LGPL-3.0+ AND LGPL-2.1+ AND BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 850
+},
+{
+    "fields": {
+        "pkgname": "office-runner",
+        "type_id": "office-runner.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            12,
+            111
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 851
+},
+{
+    "fields": {
+        "pkgname": "oflb-asana-math-fonts",
+        "type_id": "oflb-asana-math",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 852
+},
+{
+    "fields": {
+        "pkgname": "oflb-brett-fonts",
+        "type_id": "oflb-brett",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 853
+},
+{
+    "fields": {
+        "pkgname": "oflb-dignas-handwriting-fonts",
+        "type_id": "oflb-dignas-handwriting",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 854
+},
+{
+    "fields": {
+        "pkgname": "oflb-goudy-bookletter-1911-fonts",
+        "type_id": "oflb-goudy-bookletter-1911",
+        "keywords": [],
+        "project_license": "Public Domain",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 855
+},
+{
+    "fields": {
+        "pkgname": "oflb-icelandic-fonts",
+        "type_id": "oflb-icelandic",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 856
+},
+{
+    "fields": {
+        "pkgname": "oflb-notcouriersans-fonts",
+        "type_id": "oflb-notcouriersans",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 857
+},
+{
+    "fields": {
+        "pkgname": "oflb-prociono-fonts",
+        "type_id": "oflb-prociono",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 858
+},
+{
+    "fields": {
+        "pkgname": "oflb-riordonfancy-fonts",
+        "type_id": "oflb-riordonfancy",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 859
+},
+{
+    "fields": {
+        "pkgname": "oflb-smonohand-fonts",
+        "type_id": "oflb-smonohand",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 860
+},
+{
+    "fields": {
+        "pkgname": "oggconvert",
+        "type_id": "oggconvert.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 861
+},
+{
+    "fields": {
+        "pkgname": "oldstandard-sfd-fonts",
+        "type_id": "oldstandard",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 862
+},
+{
+    "fields": {
+        "pkgname": "openalchemist",
+        "type_id": "openalchemist.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 863
+},
+{
+    "fields": {
+        "pkgname": "openambit",
+        "type_id": "openambit.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            19,
+            112
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 864
+},
+{
+    "fields": {
+        "pkgname": "openarena",
+        "type_id": "openarena.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 865
+},
+{
+    "fields": {
+        "pkgname": "opendyslexic-fonts",
+        "type_id": "opendyslexic",
+        "keywords": [],
+        "project_license": "Bitstream Vera AND CC-BY-3.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 866
+},
+{
+    "fields": {
+        "pkgname": "openeuclide",
+        "type_id": "openeuclide.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 867
+},
+{
+    "fields": {
+        "pkgname": "openlierox",
+        "type_id": "openlierox.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            1,
+            2,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 868
+},
+{
+    "fields": {
+        "pkgname": "openmsx",
+        "type_id": "openmsx.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            29
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 869
+},
+{
+    "fields": {
+        "pkgname": "openscad",
+        "type_id": "openscad.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception AND CC0-1.0",
+        "type": "desktop",
+        "categories": [
+            26,
+            61,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 870
+},
+{
+    "fields": {
+        "pkgname": "OpenStego",
+        "type_id": "openstego.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 871
+},
+{
+    "fields": {
+        "pkgname": "openstv",
+        "type_id": "openstv.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 872
+},
+{
+    "fields": {
+        "pkgname": "openteacher",
+        "type_id": "openteacher.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            25,
+            46
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 873
+},
+{
+    "fields": {
+        "pkgname": "openttd",
+        "type_id": "openttd.desktop",
+        "keywords": [
+            198,
+            2348,
+            2349,
+            6041,
+            6262,
+            6263,
+            6361,
+            6362,
+            6363,
+            6364,
+            6365,
+            6366,
+            6367,
+            6368
+        ],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 874
+},
+{
+    "fields": {
+        "pkgname": "ophcrack",
+        "type_id": "ophcrack.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "desktop",
+        "categories": [
+            4,
+            68
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 875
+},
+{
+    "fields": {
+        "pkgname": "corebird",
+        "type_id": "org.baedert.corebird.desktop",
+        "keywords": [
+            1606
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 876
+},
+{
+    "fields": {
+        "pkgname": "gnome-books",
+        "type_id": "org.gnome.Books.desktop",
+        "keywords": [
+            1813,
+            6369,
+            6370,
+            6371,
+            6372,
+            6373,
+            6374,
+            6375,
+            6376,
+            6377,
+            6378,
+            6379,
+            6380,
+            6381,
+            6382,
+            6383,
+            6384,
+            6385,
+            6386,
+            6387,
+            6388,
+            6389,
+            6390,
+            6391,
+            6392,
+            6393,
+            6394,
+            6395,
+            6396,
+            6397,
+            6398,
+            6399,
+            6400,
+            6401,
+            6402,
+            6403,
+            6404,
+            6405,
+            6406,
+            6407,
+            6408,
+            6409,
+            6410,
+            6411,
+            6412,
+            6413,
+            6414,
+            6415,
+            6416,
+            6417,
+            6418,
+            6419,
+            6420,
+            6421,
+            6422,
+            6423,
+            6424,
+            6425,
+            6426,
+            6427,
+            6428,
+            6429,
+            6430,
+            6431,
+            6432,
+            6433,
+            6434,
+            6435,
+            6436,
+            6437,
+            6438,
+            6439,
+            6440,
+            6441,
+            6442,
+            6443,
+            6444,
+            6445,
+            6446,
+            6447,
+            6448,
+            6449,
+            6450
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 877
+},
+{
+    "fields": {
+        "pkgname": "gnome-boxes",
+        "type_id": "org.gnome.Boxes.desktop",
+        "keywords": [
+            6451,
+            6452,
+            6453,
+            6454,
+            6455,
+            6456,
+            6457,
+            6458,
+            6459,
+            6460,
+            6461,
+            6462,
+            6463,
+            6464,
+            6465,
+            6466,
+            6467,
+            6468,
+            6469,
+            6470,
+            6471,
+            6472,
+            6473,
+            6474,
+            6475,
+            6476,
+            6477,
+            6478,
+            6479,
+            6480,
+            6481,
+            6482,
+            6483,
+            6484,
+            6485,
+            6486,
+            6487,
+            6488,
+            6489,
+            6490,
+            6491,
+            6492,
+            6493,
+            6494,
+            6495,
+            6496,
+            6497,
+            6498,
+            6499,
+            6500,
+            6501,
+            6502,
+            6503,
+            6504,
+            6505,
+            6506,
+            6507,
+            6508,
+            6509,
+            6510,
+            6511,
+            6512,
+            6513,
+            6514,
+            6515,
+            6516,
+            6517,
+            6518,
+            6519,
+            6520,
+            6521,
+            6522,
+            6523,
+            6524,
+            6525,
+            6526,
+            6527,
+            6528,
+            6529,
+            6530,
+            6531,
+            6532,
+            6533
+        ],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 878
+},
+{
+    "fields": {
+        "pkgname": "gnome-builder",
+        "type_id": "org.gnome.Builder.desktop",
+        "keywords": [
+            6534,
+            6535
+        ],
+        "project_license": "GPL-3.0+ AND GPL-2.0+ AND LGPL-3.0+ AND LGPL-2.1+ AND MIT AND CC-BY-SA-3.0 AND CC0-1.0",
+        "type": "desktop",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 879
+},
+{
+    "fields": {
+        "pkgname": "gnome-calendar",
+        "type_id": "org.gnome.Calendar.desktop",
+        "keywords": [
+            217,
+            220,
+            275,
+            310,
+            722,
+            727,
+            732,
+            736,
+            739,
+            741,
+            742,
+            747,
+            751,
+            761,
+            767,
+            769,
+            771,
+            774,
+            776,
+            779,
+            782,
+            786,
+            788,
+            793,
+            794,
+            795,
+            1902,
+            1985,
+            2062,
+            2067,
+            6536,
+            6537,
+            6538,
+            6539,
+            6540,
+            6541,
+            6542,
+            6543,
+            6544,
+            6545,
+            6546,
+            6547,
+            6548,
+            6549,
+            6550,
+            6551,
+            6552,
+            6553,
+            6554,
+            6555,
+            6556,
+            6557,
+            6558,
+            6559,
+            6560,
+            6561,
+            6562,
+            6563,
+            6564,
+            6565,
+            6566,
+            6567,
+            6568,
+            6569,
+            6570,
+            6571,
+            6572,
+            6573,
+            6574,
+            6575,
+            6576,
+            6577,
+            6578,
+            6579,
+            6580,
+            6581,
+            6582,
+            6583,
+            6584,
+            6585,
+            6586,
+            6587,
+            6588,
+            6589,
+            6590,
+            6591,
+            6592,
+            6593,
+            6594,
+            6595,
+            6596,
+            6597,
+            6598,
+            6599,
+            6600,
+            6601,
+            6602,
+            6603,
+            6604,
+            6605,
+            6606,
+            6607,
+            6608,
+            6609,
+            6610,
+            6611,
+            6612,
+            6613,
+            6614,
+            6615,
+            6616,
+            6617
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 880
+},
+{
+    "fields": {
+        "pkgname": "gnome-characters",
+        "type_id": "org.gnome.Characters.desktop",
+        "keywords": [
+            5866,
+            5893,
+            5897,
+            5916,
+            5922,
+            5945,
+            5946,
+            5947,
+            5948,
+            5950,
+            5965,
+            5968,
+            5983,
+            5987,
+            6618,
+            6619,
+            6620,
+            6621,
+            6622,
+            6623,
+            6624,
+            6625,
+            6626,
+            6627,
+            6628,
+            6629,
+            6630,
+            6631,
+            6632,
+            6633,
+            6634,
+            6635
+        ],
+        "project_license": "BSD-3-Clause AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 881
+},
+{
+    "fields": {
+        "pkgname": "cheese",
+        "type_id": "org.gnome.Cheese.desktop",
+        "keywords": [
+            344,
+            358,
+            360,
+            363,
+            373,
+            376,
+            395,
+            397,
+            403,
+            429,
+            438,
+            444,
+            451,
+            455,
+            456,
+            457,
+            465,
+            468,
+            470,
+            502,
+            508,
+            512,
+            518,
+            524,
+            535,
+            538,
+            543,
+            548,
+            560,
+            564,
+            570,
+            573,
+            581,
+            584,
+            587,
+            591,
+            1395,
+            1423,
+            1447,
+            1466,
+            1477,
+            1501,
+            1502,
+            1553,
+            1569,
+            2375,
+            2383,
+            2399,
+            6636,
+            6637,
+            6638,
+            6639,
+            6640,
+            6641,
+            6642,
+            6643,
+            6644,
+            6645,
+            6646,
+            6647,
+            6648,
+            6649,
+            6650,
+            6651,
+            6652,
+            6653,
+            6654,
+            6655,
+            6656,
+            6657,
+            6658,
+            6659,
+            6660,
+            6661,
+            6662,
+            6663,
+            6664,
+            6665,
+            6666,
+            6667,
+            6668,
+            6669,
+            6670,
+            6671,
+            6672,
+            6673,
+            6674,
+            6675,
+            6676,
+            6677,
+            6678,
+            6679,
+            6680,
+            6681,
+            6682,
+            6683,
+            6684,
+            6685,
+            6686,
+            6687,
+            6688,
+            6689,
+            6690,
+            6691,
+            6692,
+            6693,
+            6694,
+            6695,
+            6696,
+            6697,
+            6698,
+            6699,
+            6700,
+            6701,
+            6702,
+            6703,
+            6704,
+            6705,
+            6706,
+            6707,
+            6708,
+            6709,
+            6710,
+            6711,
+            6712,
+            6713,
+            6714,
+            6715,
+            6716,
+            6717,
+            6718,
+            6719,
+            6720,
+            6721,
+            6722,
+            6723,
+            6724,
+            6725,
+            6726,
+            6727,
+            6728,
+            6729,
+            6730,
+            6731,
+            6732,
+            6733,
+            6734,
+            6735,
+            6736,
+            6737,
+            6738,
+            6739,
+            6740,
+            6741,
+            6742,
+            6743,
+            6744,
+            6745,
+            6746,
+            6747,
+            6748,
+            6749,
+            6750,
+            6751,
+            6752,
+            6753,
+            6754,
+            6755,
+            6756,
+            6757,
+            6758,
+            6759,
+            6760,
+            6761,
+            6762,
+            6763,
+            6764,
+            6765,
+            6766,
+            6767,
+            6768,
+            6769,
+            6770,
+            6771,
+            6772,
+            6773,
+            6774,
+            6775,
+            6776,
+            6777,
+            6778,
+            6779,
+            6780,
+            6781,
+            6782,
+            6783,
+            6784,
+            6785,
+            6786,
+            6787
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7,
+            65,
+            113
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 882
+},
+{
+    "fields": {
+        "pkgname": "gnome-contacts",
+        "type_id": "org.gnome.Contacts.desktop",
+        "keywords": [
+            577,
+            1880,
+            1884,
+            1893,
+            1898,
+            1900,
+            1906,
+            1913,
+            1920,
+            1931,
+            1936,
+            1942,
+            1945,
+            1950,
+            1955,
+            1962,
+            1963,
+            1967,
+            1991,
+            1995,
+            2000,
+            2012,
+            2017,
+            2023,
+            2036,
+            2047,
+            2053,
+            2058,
+            2059,
+            2065,
+            2071,
+            2093,
+            2100,
+            2103,
+            2927,
+            6788,
+            6789,
+            6790,
+            6791,
+            6792,
+            6793,
+            6794,
+            6795,
+            6796,
+            6797,
+            6798,
+            6799,
+            6800,
+            6801,
+            6802,
+            6803,
+            6804,
+            6805,
+            6806,
+            6807,
+            6808,
+            6809,
+            6810,
+            6811,
+            6812,
+            6813,
+            6814,
+            6815,
+            6816,
+            6817,
+            6818,
+            6819,
+            6820,
+            6821,
+            6822,
+            6823,
+            6824,
+            6825,
+            6826,
+            6827,
+            6828,
+            6829,
+            6830,
+            6831,
+            6832,
+            6833,
+            6834,
+            6835,
+            6836,
+            6837,
+            6838,
+            6839,
+            6840,
+            6841,
+            6842,
+            6843,
+            6844,
+            6845,
+            6846,
+            6847,
+            6848,
+            6849,
+            6850,
+            6851,
+            6852,
+            6853,
+            6854,
+            6855,
+            6856,
+            6857,
+            6858,
+            6859,
+            6860,
+            6861,
+            6862,
+            6863,
+            6864,
+            6865,
+            6866,
+            6867,
+            6868,
+            6869,
+            6870,
+            6871,
+            6872,
+            6873,
+            6874,
+            6875,
+            6876,
+            6877,
+            6878,
+            6879,
+            6880,
+            6881,
+            6882,
+            6883,
+            6884,
+            6885,
+            6886,
+            6887,
+            6888,
+            6889,
+            6890,
+            6891,
+            6892,
+            6893,
+            6894,
+            6895,
+            6896,
+            6897,
+            6898,
+            6899,
+            6900,
+            6901,
+            6902,
+            6903,
+            6904,
+            6905,
+            6906,
+            6907,
+            6908,
+            6909,
+            6910,
+            6911,
+            6912,
+            6913,
+            6914,
+            6915,
+            6916,
+            6917,
+            6918,
+            6919,
+            6920,
+            6921,
+            6922,
+            6923,
+            6924,
+            6925,
+            6926,
+            6927,
+            6928,
+            6929
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 883
+},
+{
+    "fields": {
+        "pkgname": "gnome-dictionary",
+        "type_id": "org.gnome.Dictionary.desktop",
+        "keywords": [
+            1863,
+            2929,
+            2930,
+            6276,
+            6930,
+            6931,
+            6932,
+            6933,
+            6934,
+            6935,
+            6936,
+            6937,
+            6938,
+            6939,
+            6940,
+            6941,
+            6942,
+            6943,
+            6944,
+            6945,
+            6946,
+            6947,
+            6948,
+            6949,
+            6950,
+            6951,
+            6952,
+            6953,
+            6954,
+            6955,
+            6956,
+            6957,
+            6958,
+            6959,
+            6960,
+            6961,
+            6962,
+            6963,
+            6964,
+            6965,
+            6966,
+            6967,
+            6968,
+            6969,
+            6970,
+            6971,
+            6972,
+            6973,
+            6974,
+            6975,
+            6976,
+            6977,
+            6978,
+            6979,
+            6980,
+            6981,
+            6982,
+            6983,
+            6984,
+            6985,
+            6986,
+            6987,
+            6988,
+            6989,
+            6990,
+            6991,
+            6992,
+            6993,
+            6994,
+            6995,
+            6996,
+            6997,
+            6998,
+            6999,
+            7000,
+            7001,
+            7002,
+            7003,
+            7004,
+            7005,
+            7006,
+            7007,
+            7008,
+            7009,
+            7010,
+            7011,
+            7012,
+            7013,
+            7014,
+            7015,
+            7016,
+            7017,
+            7018,
+            7019,
+            7020,
+            7021,
+            7022,
+            7023,
+            7024,
+            7025,
+            7026,
+            7027,
+            7028,
+            7029,
+            7030,
+            7031,
+            7032,
+            7033,
+            7034,
+            7035,
+            7036,
+            7037,
+            7038,
+            7039,
+            7040,
+            7041,
+            7042,
+            7043,
+            7044,
+            7045,
+            7046,
+            7047,
+            7048,
+            7049,
+            7050,
+            7051,
+            7052,
+            7053,
+            7054,
+            7055,
+            7056,
+            7057,
+            7058,
+            7059,
+            7060,
+            7061,
+            7062,
+            7063,
+            7064,
+            7065,
+            7066,
+            7067,
+            7068,
+            7069,
+            7070,
+            7071,
+            7072,
+            7073,
+            7074,
+            7075,
+            7076,
+            7077,
+            7078,
+            7079,
+            7080,
+            7081,
+            7082,
+            7083,
+            7084,
+            7085,
+            7086,
+            7087,
+            7088,
+            7089,
+            7090,
+            7091,
+            7092,
+            7093,
+            7094,
+            7095,
+            7096,
+            7097,
+            7098,
+            7099,
+            7100,
+            7101,
+            7102,
+            7103,
+            7104,
+            7105,
+            7106,
+            7107,
+            7108,
+            7109,
+            7110,
+            7111,
+            7112,
+            7113,
+            7114,
+            7115,
+            7116,
+            7117,
+            7118,
+            7119,
+            7120,
+            7121,
+            7122,
+            7123,
+            7124,
+            7125,
+            7126,
+            7127,
+            7128,
+            7129,
+            7130,
+            7131,
+            7132,
+            7133,
+            7134,
+            7135,
+            7136,
+            7137,
+            7138,
+            7139,
+            7140,
+            7141,
+            7142,
+            7143,
+            7144,
+            7145,
+            7146,
+            7147,
+            7148,
+            7149,
+            7150,
+            7151,
+            7152,
+            7153,
+            7154,
+            7155,
+            7156,
+            7157,
+            7158,
+            7159,
+            7160,
+            7161,
+            7162,
+            7163,
+            7164,
+            7165,
+            7166,
+            7167,
+            7168,
+            7169,
+            7170,
+            7171,
+            7172,
+            7173,
+            7174,
+            7175,
+            7176,
+            7177,
+            7178,
+            7179,
+            7180,
+            7181,
+            7182,
+            7183,
+            7184,
+            7185,
+            7186,
+            7187,
+            7188,
+            7189,
+            7190,
+            7191,
+            7192,
+            7193,
+            7194,
+            7195
+        ],
+        "project_license": "GPL-3.0+ AND LGPL-2.1+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            13,
+            59
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 884
+},
+{
+    "fields": {
+        "pkgname": "gnome-documents",
+        "type_id": "org.gnome.Documents.desktop",
+        "keywords": [
+            995,
+            1002,
+            1047,
+            1053,
+            1081,
+            1084,
+            1088,
+            1769,
+            1770,
+            1778,
+            1780,
+            1791,
+            1794,
+            1811,
+            1829,
+            1831,
+            1838,
+            1848,
+            1855,
+            1860,
+            1864,
+            1865,
+            6151,
+            6371,
+            6387,
+            7196,
+            7197,
+            7198,
+            7199,
+            7200,
+            7201,
+            7202,
+            7203,
+            7204,
+            7205,
+            7206,
+            7207,
+            7208,
+            7209,
+            7210,
+            7211,
+            7212,
+            7213,
+            7214,
+            7215,
+            7216,
+            7217,
+            7218,
+            7219,
+            7220,
+            7221,
+            7222,
+            7223,
+            7224,
+            7225,
+            7226,
+            7227,
+            7228,
+            7229,
+            7230,
+            7231,
+            7232,
+            7233,
+            7234,
+            7235,
+            7236,
+            7237,
+            7238,
+            7239,
+            7240,
+            7241,
+            7242,
+            7243,
+            7244,
+            7245,
+            7246,
+            7247,
+            7248,
+            7249,
+            7250,
+            7251,
+            7252,
+            7253,
+            7254,
+            7255,
+            7256,
+            7257,
+            7258,
+            7259,
+            7260,
+            7261,
+            7262,
+            7263,
+            7264,
+            7265,
+            7266,
+            7267,
+            7268,
+            7269,
+            7270,
+            7271,
+            7272,
+            7273,
+            7274,
+            7275
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 885
+},
+{
+    "fields": {
+        "pkgname": "file-roller",
+        "type_id": "org.gnome.FileRoller.desktop",
+        "keywords": [
+            7276,
+            7277,
+            7278,
+            7279,
+            7280,
+            7281,
+            7282,
+            7283,
+            7284,
+            7285,
+            7286,
+            7287,
+            7288,
+            7289,
+            7290,
+            7291,
+            7292,
+            7293,
+            7294,
+            7295,
+            7296,
+            7297,
+            7298,
+            7299,
+            7300,
+            7301,
+            7302,
+            7303,
+            7304,
+            7305,
+            7306,
+            7307,
+            7308,
+            7309,
+            7310,
+            7311,
+            7312,
+            7313,
+            7314,
+            7315,
+            7316,
+            7317,
+            7318,
+            7319,
+            7320,
+            7321,
+            7322,
+            7323,
+            7324,
+            7325,
+            7326,
+            7327,
+            7328,
+            7329,
+            7330,
+            7331,
+            7332,
+            7333,
+            7334,
+            7335,
+            7336,
+            7337,
+            7338,
+            7339,
+            7340,
+            7341,
+            7342,
+            7343,
+            7344,
+            7345,
+            7346,
+            7347,
+            7348,
+            7349,
+            7350,
+            7351,
+            7352,
+            7353,
+            7354,
+            7355,
+            7356,
+            7357,
+            7358,
+            7359,
+            7360,
+            7361,
+            7362,
+            7363,
+            7364,
+            7365,
+            7366,
+            7367,
+            7368,
+            7369,
+            7370,
+            7371,
+            7372,
+            7373,
+            7374,
+            7375,
+            7376,
+            7377,
+            7378,
+            7379,
+            7380,
+            7381,
+            7382,
+            7383,
+            7384,
+            7385,
+            7386,
+            7387,
+            7388,
+            7389,
+            7390,
+            7391,
+            7392,
+            7393,
+            7394,
+            7395,
+            7396,
+            7397,
+            7398,
+            7399,
+            7400,
+            7401,
+            7402,
+            7403,
+            7404,
+            7405,
+            7406,
+            7407,
+            7408,
+            7409,
+            7410,
+            7411,
+            7412,
+            7413,
+            7414,
+            7415,
+            7416,
+            7417,
+            7418,
+            7419,
+            7420,
+            7421,
+            7422,
+            7423,
+            7424,
+            7425,
+            7426,
+            7427,
+            7428,
+            7429,
+            7430,
+            7431,
+            7432,
+            7433,
+            7434,
+            7435,
+            7436,
+            7437,
+            7438,
+            7439,
+            7440,
+            7441,
+            7442
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            53,
+            54
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 886
+},
+{
+    "fields": {
+        "pkgname": "gnome-logs",
+        "type_id": "org.gnome.Logs.desktop",
+        "keywords": [
+            130,
+            842,
+            844,
+            845,
+            848,
+            849,
+            852,
+            853,
+            857,
+            859,
+            862,
+            863,
+            866,
+            874,
+            1923,
+            2552,
+            2554,
+            2558,
+            2569,
+            2572,
+            4455,
+            4468,
+            4470,
+            4475,
+            4477,
+            4480,
+            4485,
+            4489,
+            4498,
+            4501,
+            4502,
+            4503,
+            4504,
+            4505,
+            4507,
+            4509,
+            4510,
+            4511,
+            4516,
+            4517,
+            4518,
+            4519,
+            4520,
+            4521,
+            4522,
+            4524,
+            4526,
+            4530,
+            4535,
+            4536,
+            4538,
+            4539,
+            4541,
+            4542,
+            4547,
+            4555,
+            4557,
+            4559,
+            4561,
+            4562,
+            4564,
+            4565,
+            4566,
+            4568,
+            4569,
+            4570,
+            4573,
+            4574,
+            4576,
+            4581,
+            4582,
+            4584,
+            4585,
+            4587,
+            4588,
+            4842,
+            5092,
+            5099,
+            6316,
+            6569,
+            7443,
+            7444,
+            7445,
+            7446,
+            7447,
+            7448,
+            7449,
+            7450,
+            7451,
+            7452,
+            7453,
+            7454,
+            7455,
+            7456,
+            7457,
+            7458,
+            7459,
+            7460,
+            7461,
+            7462,
+            7463,
+            7464,
+            7465,
+            7466,
+            7467,
+            7468,
+            7469,
+            7470,
+            7471,
+            7472,
+            7473,
+            7474,
+            7475,
+            7476,
+            7477,
+            7478,
+            7479,
+            7480,
+            7481,
+            7482,
+            7483,
+            7484,
+            7485,
+            7486,
+            7487,
+            7488,
+            7489,
+            7490,
+            7491,
+            7492,
+            7493,
+            7494,
+            7495,
+            7496,
+            7497,
+            7498,
+            7499,
+            7500,
+            7501,
+            7502,
+            7503,
+            7504,
+            7505,
+            7506,
+            7507,
+            7508,
+            7509,
+            7510,
+            7511,
+            7512,
+            7513,
+            7514,
+            7515,
+            7516,
+            7517,
+            7518,
+            7519,
+            7520,
+            7521,
+            7522,
+            7523,
+            7524,
+            7525,
+            7526,
+            7527,
+            7528,
+            7529,
+            7530,
+            7531,
+            7532,
+            7533,
+            7534,
+            7535,
+            7536,
+            7537,
+            7538,
+            7539,
+            7540,
+            7541,
+            7542,
+            7543,
+            7544,
+            7545,
+            7546,
+            7547,
+            7548,
+            7549,
+            7550,
+            7551
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            5,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 887
+},
+{
+    "fields": {
+        "pkgname": "gnome-maps",
+        "type_id": "org.gnome.Maps.desktop",
+        "keywords": [
+            2319,
+            7552,
+            7553,
+            7554,
+            7555,
+            7556,
+            7557,
+            7558,
+            7559,
+            7560,
+            7561,
+            7562,
+            7563,
+            7564,
+            7565,
+            7566,
+            7567,
+            7568,
+            7569,
+            7570,
+            7571,
+            7572,
+            7573,
+            7574,
+            7575,
+            7576,
+            7577,
+            7578,
+            7579,
+            7580,
+            7581,
+            7582,
+            7583,
+            7584,
+            7585,
+            7586,
+            7587,
+            7588,
+            7589,
+            7590,
+            7591,
+            7592,
+            7593,
+            7594,
+            7595,
+            7596,
+            7597,
+            7598,
+            7599,
+            7600,
+            7601,
+            7602,
+            7603,
+            7604,
+            7605,
+            7606,
+            7607,
+            7608,
+            7609,
+            7610,
+            7611,
+            7612,
+            7613,
+            7614,
+            7615,
+            7616,
+            7617,
+            7618,
+            7619,
+            7620
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 888
+},
+{
+    "fields": {
+        "pkgname": "gnome-multi-writer",
+        "type_id": "org.gnome.MultiWriter.desktop",
+        "keywords": [
+            575,
+            1408,
+            1447,
+            1505,
+            1528,
+            1531,
+            2356,
+            2366,
+            2371,
+            2396,
+            3145,
+            3180,
+            3198,
+            3585,
+            3640,
+            7621,
+            7622,
+            7623,
+            7624,
+            7625,
+            7626,
+            7627,
+            7628,
+            7629,
+            7630,
+            7631,
+            7632,
+            7633,
+            7634,
+            7635,
+            7636,
+            7637,
+            7638,
+            7639,
+            7640,
+            7641,
+            7642,
+            7643,
+            7644,
+            7645,
+            7646,
+            7647,
+            7648,
+            7649,
+            7650,
+            7651,
+            7652,
+            7653,
+            7654
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 889
+},
+{
+    "fields": {
+        "pkgname": "nautilus",
+        "type_id": "org.gnome.Nautilus.desktop",
+        "keywords": [
+            348,
+            353,
+            356,
+            362,
+            368,
+            398,
+            400,
+            412,
+            415,
+            426,
+            431,
+            443,
+            454,
+            467,
+            474,
+            478,
+            489,
+            496,
+            498,
+            510,
+            515,
+            525,
+            540,
+            557,
+            561,
+            569,
+            574,
+            577,
+            582,
+            721,
+            1658,
+            1668,
+            3106,
+            3131,
+            3202,
+            3206,
+            3237,
+            3280,
+            3315,
+            3352,
+            3438,
+            3554,
+            3618,
+            3619,
+            3630,
+            3642,
+            4615,
+            4637,
+            4668,
+            4691,
+            4773,
+            4839,
+            4841,
+            4847,
+            4893,
+            4972,
+            4979,
+            5061,
+            5063,
+            5064,
+            5067,
+            5068,
+            5073,
+            5090,
+            5097,
+            6781,
+            7655,
+            7656,
+            7657,
+            7658,
+            7659,
+            7660,
+            7661,
+            7662,
+            7663,
+            7664,
+            7665,
+            7666,
+            7667,
+            7668,
+            7669,
+            7670,
+            7671,
+            7672,
+            7673,
+            7674,
+            7675,
+            7676,
+            7677,
+            7678,
+            7679,
+            7680,
+            7681,
+            7682,
+            7683,
+            7684,
+            7685,
+            7686,
+            7687,
+            7688,
+            7689,
+            7690,
+            7691,
+            7692,
+            7693,
+            7694,
+            7695,
+            7696,
+            7697,
+            7698,
+            7699,
+            7700,
+            7701,
+            7702,
+            7703,
+            7704,
+            7705,
+            7706,
+            7707,
+            7708,
+            7709,
+            7710,
+            7711,
+            7712,
+            7713,
+            7714,
+            7715,
+            7716,
+            7717,
+            7718,
+            7719,
+            7720,
+            7721,
+            7722,
+            7723,
+            7724,
+            7725,
+            7726,
+            7727,
+            7728,
+            7729,
+            7730,
+            7731,
+            7732,
+            7733,
+            7734,
+            7735,
+            7736,
+            7737,
+            7738,
+            7739,
+            7740,
+            7741,
+            7742,
+            7743,
+            7744,
+            7745,
+            7746,
+            7747,
+            7748,
+            7749,
+            7750,
+            7751,
+            7752,
+            7753,
+            7754,
+            7755,
+            7756,
+            7757,
+            7758,
+            7759,
+            7760,
+            7761,
+            7762,
+            7763,
+            7764,
+            7765,
+            7766,
+            7767,
+            7768,
+            7769,
+            7770,
+            7771,
+            7772,
+            7773,
+            7774,
+            7775,
+            7776,
+            7777,
+            7778,
+            7779,
+            7780,
+            7781,
+            7782,
+            7783,
+            7784,
+            7785,
+            7786,
+            7787,
+            7788,
+            7789,
+            7790,
+            7791,
+            7792,
+            7793,
+            7794,
+            7795,
+            7796,
+            7797,
+            7798,
+            7799,
+            7800,
+            7801,
+            7802,
+            7803,
+            7804,
+            7805,
+            7806,
+            7807,
+            7808,
+            7809,
+            7810,
+            7811,
+            7812,
+            7813,
+            7814,
+            7815,
+            7816,
+            7817,
+            7818,
+            7819,
+            7820,
+            7821,
+            7822,
+            7823,
+            7824,
+            7825,
+            7826,
+            7827,
+            7828,
+            7829,
+            7830,
+            7831,
+            7832,
+            7833,
+            7834,
+            7835,
+            7836,
+            7837,
+            7838,
+            7839,
+            7840,
+            7841,
+            7842,
+            7843,
+            7844,
+            7845,
+            7846,
+            7847,
+            7848,
+            7849,
+            7850,
+            7851,
+            7852,
+            7853,
+            7854,
+            7855,
+            7856,
+            7857,
+            7858,
+            7859,
+            7860,
+            7861,
+            7862,
+            7863,
+            7864,
+            7865,
+            7866,
+            7867,
+            7868,
+            7869,
+            7870,
+            7871,
+            7872,
+            7873,
+            7874,
+            7875,
+            7876,
+            7877,
+            7878,
+            7879,
+            7880,
+            7881,
+            7882,
+            7883,
+            7884,
+            7885,
+            7886,
+            7887,
+            7888,
+            7889,
+            7890,
+            7891,
+            7892,
+            7893,
+            7894,
+            7895,
+            7896,
+            7897,
+            7898,
+            7899,
+            7900,
+            7901,
+            7902,
+            7903,
+            7904,
+            7905,
+            7906,
+            7907,
+            7908,
+            7909,
+            7910,
+            7911,
+            7912,
+            7913,
+            7914,
+            7915,
+            7916,
+            7917,
+            7918,
+            7919,
+            7920,
+            7921,
+            7922,
+            7923,
+            7924,
+            7925,
+            7926,
+            7927,
+            7928,
+            7929,
+            7930,
+            7931,
+            7932,
+            7933,
+            7934,
+            7935,
+            7936,
+            7937,
+            7938
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            3,
+            5,
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 890
+},
+{
+    "fields": {
+        "pkgname": "gnome-photos",
+        "type_id": "org.gnome.Photos.desktop",
+        "keywords": [
+            878,
+            1375,
+            1395,
+            1396,
+            1418,
+            1423,
+            1455,
+            1462,
+            1466,
+            1467,
+            1476,
+            1477,
+            1484,
+            1486,
+            1502,
+            1505,
+            1506,
+            1513,
+            1522,
+            1571,
+            1575,
+            1578,
+            2379,
+            2383,
+            2393,
+            2395,
+            2396,
+            2411,
+            2412,
+            3467,
+            5861,
+            6661,
+            6662,
+            6663,
+            6743,
+            6744,
+            6784,
+            6786,
+            7939,
+            7940,
+            7941,
+            7942,
+            7943,
+            7944,
+            7945,
+            7946,
+            7947,
+            7948,
+            7949,
+            7950,
+            7951,
+            7952,
+            7953,
+            7954,
+            7955,
+            7956,
+            7957,
+            7958,
+            7959,
+            7960,
+            7961,
+            7962,
+            7963,
+            7964,
+            7965,
+            7966,
+            7967,
+            7968,
+            7969,
+            7970,
+            7971,
+            7972,
+            7973,
+            7974,
+            7975,
+            7976,
+            7977,
+            7978,
+            7979,
+            7980,
+            7981,
+            7982,
+            7983,
+            7984,
+            7985,
+            7986,
+            7987,
+            7988,
+            7989,
+            7990,
+            7991,
+            7992,
+            7993,
+            7994,
+            7995,
+            7996,
+            7997,
+            7998,
+            7999,
+            8000,
+            8001,
+            8002,
+            8003,
+            8004,
+            8005,
+            8006,
+            8007,
+            8008,
+            8009,
+            8010,
+            8011,
+            8012,
+            8013,
+            8014,
+            8015,
+            8016,
+            8017,
+            8018,
+            8019,
+            8020,
+            8021,
+            8022,
+            8023,
+            8024,
+            8025,
+            8026,
+            8027,
+            8028,
+            8029,
+            8030,
+            8031,
+            8032
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            5,
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 891
+},
+{
+    "fields": {
+        "pkgname": "polari",
+        "type_id": "org.gnome.Polari.desktop",
+        "keywords": [
+            1131,
+            1184,
+            1192,
+            1238,
+            1244,
+            1264,
+            1268,
+            1276,
+            1279,
+            1297,
+            1308,
+            1312,
+            1320,
+            1345,
+            1350,
+            1356,
+            1609,
+            1633,
+            1649,
+            1697,
+            1724,
+            1725,
+            1729,
+            5988,
+            5994,
+            8033,
+            8034,
+            8035,
+            8036,
+            8037,
+            8038,
+            8039,
+            8040,
+            8041,
+            8042,
+            8043,
+            8044,
+            8045,
+            8046,
+            8047,
+            8048,
+            8049,
+            8050,
+            8051,
+            8052,
+            8053,
+            8054,
+            8055,
+            8056,
+            8057,
+            8058,
+            8059,
+            8060,
+            8061,
+            8062,
+            8063,
+            8064,
+            8065,
+            8066,
+            8067,
+            8068,
+            8069,
+            8070,
+            8071,
+            8072,
+            8073,
+            8074,
+            8075,
+            8076,
+            8077,
+            8078,
+            8079,
+            8080,
+            8081,
+            8082,
+            8083,
+            8084,
+            8085,
+            8086,
+            8087,
+            8088,
+            8089,
+            8090,
+            8091,
+            8092,
+            8093,
+            8094,
+            8095,
+            8096,
+            8097,
+            8098,
+            8099,
+            8100,
+            8101,
+            8102,
+            8103,
+            8104,
+            8105,
+            8106,
+            8107,
+            8108,
+            8109,
+            8110,
+            8111,
+            8112,
+            8113
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            23,
+            70
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 892
+},
+{
+    "fields": {
+        "pkgname": "gnome-shell-extension-pomodoro",
+        "type_id": "org.gnome.Pomodoro.desktop",
+        "keywords": [
+            1944,
+            5405,
+            5425,
+            5454,
+            8114,
+            8115,
+            8116,
+            8117,
+            8118,
+            8119,
+            8120,
+            8121,
+            8122,
+            8123,
+            8124,
+            8125,
+            8126,
+            8127,
+            8128,
+            8129,
+            8130,
+            8131,
+            8132,
+            8133
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 893
+},
+{
+    "fields": {
+        "pkgname": "gnome-screenshot",
+        "type_id": "org.gnome.Screenshot.desktop",
+        "keywords": [
+            363,
+            543,
+            548,
+            709,
+            710,
+            1375,
+            1447,
+            1501,
+            2151,
+            3550,
+            6284,
+            6285,
+            6662,
+            6666,
+            6701,
+            6702,
+            6778,
+            6779,
+            8134,
+            8135,
+            8136,
+            8137,
+            8138,
+            8139,
+            8140,
+            8141,
+            8142,
+            8143,
+            8144,
+            8145,
+            8146,
+            8147,
+            8148,
+            8149,
+            8150,
+            8151,
+            8152,
+            8153,
+            8154,
+            8155,
+            8156,
+            8157,
+            8158,
+            8159,
+            8160,
+            8161,
+            8162,
+            8163,
+            8164,
+            8165,
+            8166,
+            8167,
+            8168,
+            8169,
+            8170,
+            8171,
+            8172,
+            8173,
+            8174,
+            8175,
+            8176,
+            8177,
+            8178,
+            8179,
+            8180,
+            8181,
+            8182,
+            8183,
+            8184,
+            8185,
+            8186,
+            8187,
+            8188,
+            8189,
+            8190,
+            8191,
+            8192,
+            8193,
+            8194,
+            8195,
+            8196,
+            8197,
+            8198,
+            8199,
+            8200,
+            8201,
+            8202,
+            8203,
+            8204,
+            8205,
+            8206,
+            8207,
+            8208,
+            8209,
+            8210,
+            8211,
+            8212,
+            8213,
+            8214,
+            8215,
+            8216,
+            8217,
+            8218,
+            8219,
+            8220,
+            8221,
+            8222,
+            8223,
+            8224,
+            8225,
+            8226,
+            8227,
+            8228,
+            8229,
+            8230,
+            8231,
+            8232,
+            8233,
+            8234,
+            8235,
+            8236,
+            8237,
+            8238,
+            8239,
+            8240,
+            8241,
+            8242,
+            8243,
+            8244,
+            8245,
+            8246,
+            8247,
+            8248,
+            8249,
+            8250,
+            8251,
+            8252,
+            8253,
+            8254,
+            8255,
+            8256,
+            8257,
+            8258,
+            8259,
+            8260,
+            8261,
+            8262,
+            8263,
+            8264,
+            8265,
+            8266,
+            8267,
+            8268,
+            8269,
+            8270,
+            8271,
+            8272,
+            8273,
+            8274,
+            8275,
+            8276,
+            8277,
+            8278,
+            8279,
+            8280,
+            8281,
+            8282,
+            8283,
+            8284,
+            8285,
+            8286,
+            8287,
+            8288,
+            8289,
+            8290,
+            8291,
+            8292,
+            8293,
+            8294,
+            8295,
+            8296,
+            8297,
+            8298,
+            8299,
+            8300,
+            8301,
+            8302,
+            8303,
+            8304,
+            8305,
+            8306,
+            8307,
+            8308,
+            8309,
+            8310,
+            8311,
+            8312,
+            8313,
+            8314,
+            8315,
+            8316,
+            8317,
+            8318,
+            8319,
+            8320,
+            8321,
+            8322,
+            8323,
+            8324,
+            8325,
+            8326,
+            8327,
+            8328,
+            8329,
+            8330,
+            8331,
+            8332,
+            8333,
+            8334,
+            8335,
+            8336,
+            8337,
+            8338,
+            8339,
+            8340,
+            8341,
+            8342
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 894
+},
+{
+    "fields": {
+        "pkgname": "gnome-software",
+        "type_id": "org.gnome.Software.desktop",
+        "keywords": [
+            16,
+            154,
+            181,
+            183,
+            610,
+            652,
+            686,
+            689,
+            738,
+            831,
+            2963,
+            2967,
+            2971,
+            2972,
+            2983,
+            2985,
+            2987,
+            2990,
+            2991,
+            2993,
+            3003,
+            3016,
+            3018,
+            3021,
+            3024,
+            3025,
+            3031,
+            3032,
+            3034,
+            3041,
+            3052,
+            3058,
+            3060,
+            3063,
+            3065,
+            3068,
+            3075,
+            3077,
+            3079,
+            3080,
+            3100,
+            3101,
+            3102,
+            5315,
+            5516,
+            5517,
+            5518,
+            5519,
+            5524,
+            5526,
+            5527,
+            5533,
+            5535,
+            5537,
+            5546,
+            5547,
+            5548,
+            5550,
+            5552,
+            5553,
+            5554,
+            5555,
+            5557,
+            5559,
+            5560,
+            5561,
+            5572,
+            5573,
+            5574,
+            5575,
+            5576,
+            5577,
+            5579,
+            5580,
+            5581,
+            5582,
+            5583,
+            5584,
+            5586,
+            5587,
+            5588,
+            5591,
+            5592,
+            5593,
+            5595,
+            5596,
+            5597,
+            5598,
+            5599,
+            5600,
+            5601,
+            5602,
+            5604,
+            5607,
+            5608,
+            5611,
+            5617,
+            5618,
+            5620,
+            5621,
+            5623,
+            5624,
+            5625,
+            5626,
+            5627,
+            5641,
+            5642,
+            5643,
+            5645,
+            5646,
+            5647,
+            5651,
+            5652,
+            5657,
+            5658,
+            5659,
+            5662,
+            5663,
+            5664,
+            5666,
+            5667,
+            5668,
+            5670,
+            5671,
+            5672,
+            5673,
+            5674,
+            5675,
+            5676,
+            5677,
+            5679,
+            5680,
+            5682,
+            5685,
+            5686,
+            5688,
+            5690,
+            5691,
+            5692,
+            5694,
+            5698,
+            5700,
+            5701,
+            5702,
+            5703,
+            5704,
+            5705,
+            5706,
+            5708,
+            5709,
+            5710,
+            5711,
+            5713,
+            5716,
+            5719,
+            5721,
+            5723,
+            5728,
+            5729,
+            5731,
+            5733,
+            5737,
+            5739,
+            5740,
+            5741,
+            5742,
+            5743,
+            8343,
+            8344,
+            8345,
+            8346,
+            8347,
+            8348,
+            8349,
+            8350,
+            8351,
+            8352,
+            8353,
+            8354,
+            8355,
+            8356,
+            8357,
+            8358,
+            8359,
+            8360,
+            8361,
+            8362,
+            8363,
+            8364,
+            8365,
+            8366,
+            8367,
+            8368,
+            8369,
+            8370,
+            8371,
+            8372,
+            8373,
+            8374,
+            8375,
+            8376,
+            8377,
+            8378,
+            8379,
+            8380,
+            8381,
+            8382,
+            8383,
+            8384,
+            8385,
+            8386,
+            8387,
+            8388,
+            8389,
+            8390,
+            8391,
+            8392,
+            8393,
+            8394,
+            8395,
+            8396,
+            8397,
+            8398,
+            8399,
+            8400,
+            8401,
+            8402,
+            8403,
+            8404,
+            8405,
+            8406,
+            8407,
+            8408,
+            8409,
+            8410,
+            8411,
+            8412,
+            8413,
+            8414,
+            8415,
+            8416,
+            8417,
+            8418,
+            8419,
+            8420,
+            8421,
+            8422,
+            8423,
+            8424,
+            8425,
+            8426,
+            8427,
+            8428,
+            8429,
+            8430,
+            8431,
+            8432,
+            8433,
+            8434,
+            8435,
+            8436,
+            8437,
+            8438,
+            8439,
+            8440,
+            8441,
+            8442,
+            8443,
+            8444,
+            8445,
+            8446,
+            8447,
+            8448,
+            8449,
+            8450,
+            8451,
+            8452,
+            8453,
+            8454,
+            8455,
+            8456,
+            8457,
+            8458,
+            8459,
+            8460,
+            8461,
+            8462,
+            8463,
+            8464,
+            8465,
+            8466,
+            8467,
+            8468,
+            8469,
+            8470,
+            8471,
+            8472,
+            8473,
+            8474,
+            8475,
+            8476,
+            8477,
+            8478,
+            8479,
+            8480,
+            8481,
+            8482,
+            8483,
+            8484,
+            8485,
+            8486,
+            8487,
+            8488,
+            8489,
+            8490,
+            8491,
+            8492,
+            8493,
+            8494,
+            8495,
+            8496,
+            8497,
+            8498,
+            8499,
+            8500,
+            8501,
+            8502,
+            8503,
+            8504,
+            8505,
+            8506,
+            8507,
+            8508,
+            8509,
+            8510,
+            8511,
+            8512,
+            8513,
+            8514,
+            8515,
+            8516,
+            8517,
+            8518,
+            8519,
+            8520,
+            8521,
+            8522,
+            8523,
+            8524,
+            8525,
+            8526,
+            8527,
+            8528,
+            8529,
+            8530,
+            8531,
+            8532,
+            8533,
+            8534,
+            8535,
+            8536,
+            8537,
+            8538,
+            8539,
+            8540,
+            8541,
+            8542,
+            8543,
+            8544,
+            8545,
+            8546,
+            8547,
+            8548,
+            8549,
+            8550,
+            8551,
+            8552,
+            8553,
+            8554,
+            8555,
+            8556,
+            8557,
+            8558,
+            8559,
+            8560,
+            8561,
+            8562,
+            8563,
+            8564,
+            8565,
+            8566,
+            8567,
+            8568,
+            8569,
+            8570,
+            8571,
+            8572,
+            8573,
+            8574,
+            8575,
+            8576,
+            8577,
+            8578,
+            8579,
+            8580,
+            8581,
+            8582,
+            8583,
+            8584,
+            8585,
+            8586,
+            8587,
+            8588,
+            8589,
+            8590,
+            8591,
+            8592,
+            8593,
+            8594,
+            8595,
+            8596,
+            8597,
+            8598,
+            8599,
+            8600,
+            8601,
+            8602,
+            8603,
+            8604,
+            8605,
+            8606,
+            8607,
+            8608,
+            8609,
+            8610,
+            8611,
+            8612,
+            8613,
+            8614,
+            8615,
+            8616,
+            8617,
+            8618,
+            8619,
+            8620,
+            8621,
+            8622,
+            8623,
+            8624,
+            8625,
+            8626,
+            8627,
+            8628
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            50
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 895
+},
+{
+    "fields": {
+        "pkgname": "gnome-sound-recorder",
+        "type_id": "org.gnome.SoundRecorder.desktop",
+        "keywords": [
+            355,
+            374,
+            377,
+            401,
+            402,
+            414,
+            436,
+            440,
+            442,
+            453,
+            460,
+            472,
+            497,
+            541,
+            549,
+            585,
+            2359,
+            6698,
+            7460,
+            7629,
+            7640,
+            8168,
+            8217,
+            8407,
+            8424,
+            8430,
+            8440,
+            8452,
+            8458,
+            8472,
+            8478,
+            8493,
+            8499,
+            8501,
+            8505,
+            8534,
+            8545,
+            8550,
+            8571,
+            8580,
+            8599,
+            8603,
+            8629,
+            8630,
+            8631,
+            8632,
+            8633,
+            8634,
+            8635,
+            8636,
+            8637,
+            8638,
+            8639,
+            8640,
+            8641,
+            8642,
+            8643,
+            8644,
+            8645,
+            8646,
+            8647,
+            8648,
+            8649,
+            8650,
+            8651,
+            8652,
+            8653,
+            8654,
+            8655,
+            8656,
+            8657,
+            8658,
+            8659,
+            8660,
+            8661,
+            8662,
+            8663,
+            8664,
+            8665,
+            8666,
+            8667,
+            8668,
+            8669,
+            8670,
+            8671,
+            8672,
+            8673,
+            8674,
+            8675,
+            8676,
+            8677,
+            8678,
+            8679,
+            8680,
+            8681,
+            8682,
+            8683,
+            8684,
+            8685,
+            8686,
+            8687,
+            8688,
+            8689,
+            8690,
+            8691,
+            8692,
+            8693,
+            8694,
+            8695,
+            8696,
+            8697,
+            8698,
+            8699,
+            8700,
+            8701,
+            8702,
+            8703,
+            8704,
+            8705,
+            8706,
+            8707,
+            8708,
+            8709,
+            8710,
+            8711,
+            8712,
+            8713,
+            8714,
+            8715,
+            8716,
+            8717,
+            8718,
+            8719,
+            8720,
+            8721,
+            8722,
+            8723,
+            8724,
+            8725,
+            8726,
+            8727,
+            8728,
+            8729,
+            8730,
+            8731,
+            8732
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 896
+},
+{
+    "fields": {
+        "pkgname": "gnome-terminal",
+        "type_id": "org.gnome.Terminal.desktop",
+        "keywords": [
+            579,
+            5061,
+            7174,
+            7918,
+            8733,
+            8734,
+            8735,
+            8736,
+            8737,
+            8738,
+            8739,
+            8740,
+            8741,
+            8742,
+            8743,
+            8744,
+            8745,
+            8746,
+            8747,
+            8748,
+            8749,
+            8750,
+            8751,
+            8752,
+            8753,
+            8754,
+            8755,
+            8756,
+            8757,
+            8758,
+            8759,
+            8760,
+            8761,
+            8762,
+            8763,
+            8764,
+            8765,
+            8766,
+            8767,
+            8768,
+            8769,
+            8770,
+            8771,
+            8772,
+            8773,
+            8774,
+            8775,
+            8776,
+            8777,
+            8778,
+            8779,
+            8780,
+            8781,
+            8782,
+            8783,
+            8784,
+            8785,
+            8786,
+            8787,
+            8788,
+            8789,
+            8790,
+            8791,
+            8792,
+            8793,
+            8794,
+            8795,
+            8796,
+            8797,
+            8798,
+            8799,
+            8800,
+            8801,
+            8802,
+            8803,
+            8804,
+            8805,
+            8806,
+            8807,
+            8808,
+            8809,
+            8810,
+            8811,
+            8812,
+            8813,
+            8814,
+            8815,
+            8816,
+            8817,
+            8818,
+            8819,
+            8820,
+            8821,
+            8822,
+            8823,
+            8824,
+            8825,
+            8826,
+            8827,
+            8828,
+            8829,
+            8830,
+            8831,
+            8832,
+            8833,
+            8834,
+            8835,
+            8836,
+            8837,
+            8838,
+            8839,
+            8840,
+            8841,
+            8842,
+            8843,
+            8844,
+            8845,
+            8846,
+            8847,
+            8848,
+            8849,
+            8850,
+            8851,
+            8852,
+            8853,
+            8854,
+            8855,
+            8856,
+            8857,
+            8858,
+            8859,
+            8860,
+            8861,
+            8862,
+            8863,
+            8864,
+            8865,
+            8866,
+            8867,
+            8868,
+            8869,
+            8870,
+            8871,
+            8872,
+            8873,
+            8874,
+            8875,
+            8876,
+            8877,
+            8878,
+            8879,
+            8880,
+            8881,
+            8882,
+            8883,
+            8884,
+            8885,
+            8886,
+            8887,
+            8888,
+            8889,
+            8890,
+            8891,
+            8892,
+            8893,
+            8894,
+            8895,
+            8896,
+            8897,
+            8898,
+            8899,
+            8900,
+            8901,
+            8902,
+            8903,
+            8904,
+            8905,
+            8906,
+            8907,
+            8908,
+            8909,
+            8910,
+            8911,
+            8912,
+            8913,
+            8914,
+            8915,
+            8916,
+            8917,
+            8918,
+            8919,
+            8920,
+            8921,
+            8922,
+            8923,
+            8924,
+            8925,
+            8926,
+            8927,
+            8928,
+            8929,
+            8930,
+            8931,
+            8932,
+            8933,
+            8934,
+            8935,
+            8936,
+            8937,
+            8938,
+            8939,
+            8940,
+            8941,
+            8942,
+            8943,
+            8944,
+            8945,
+            8946,
+            8947,
+            8948,
+            8949,
+            8950,
+            8951,
+            8952,
+            8953,
+            8954,
+            8955,
+            8956,
+            8957,
+            8958,
+            8959,
+            8960,
+            8961,
+            8962,
+            8963,
+            8964,
+            8965,
+            8966,
+            8967,
+            8968,
+            8969,
+            8970,
+            8971,
+            8972,
+            8973,
+            8974
+        ],
+        "project_license": "GPL-3.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 897
+},
+{
+    "fields": {
+        "pkgname": "totem",
+        "type_id": "org.gnome.Totem.desktop",
+        "keywords": [
+            349,
+            356,
+            358,
+            412,
+            431,
+            433,
+            437,
+            438,
+            441,
+            454,
+            455,
+            457,
+            458,
+            465,
+            467,
+            468,
+            470,
+            471,
+            489,
+            491,
+            498,
+            499,
+            538,
+            539,
+            540,
+            543,
+            546,
+            548,
+            556,
+            557,
+            558,
+            569,
+            570,
+            584,
+            586,
+            587,
+            590,
+            591,
+            1558,
+            2358,
+            2363,
+            2368,
+            2372,
+            2391,
+            2397,
+            2409,
+            3131,
+            3199,
+            3315,
+            3323,
+            3530,
+            3555,
+            3562,
+            3925,
+            3929,
+            3931,
+            3934,
+            3943,
+            3944,
+            3952,
+            3955,
+            3956,
+            3959,
+            3961,
+            3965,
+            3968,
+            3972,
+            3975,
+            3978,
+            3980,
+            3984,
+            3986,
+            3991,
+            3992,
+            5847,
+            6654,
+            6700,
+            6731,
+            6765,
+            7751,
+            7815,
+            7841,
+            8975,
+            8976,
+            8977,
+            8978,
+            8979,
+            8980,
+            8981,
+            8982,
+            8983,
+            8984,
+            8985,
+            8986,
+            8987,
+            8988,
+            8989,
+            8990,
+            8991,
+            8992,
+            8993,
+            8994,
+            8995,
+            8996,
+            8997,
+            8998,
+            8999,
+            9000,
+            9001,
+            9002,
+            9003,
+            9004,
+            9005,
+            9006,
+            9007,
+            9008,
+            9009,
+            9010,
+            9011,
+            9012,
+            9013,
+            9014,
+            9015,
+            9016,
+            9017,
+            9018,
+            9019,
+            9020,
+            9021,
+            9022,
+            9023,
+            9024,
+            9025,
+            9026,
+            9027,
+            9028,
+            9029,
+            9030,
+            9031,
+            9032,
+            9033,
+            9034,
+            9035,
+            9036,
+            9037,
+            9038,
+            9039,
+            9040,
+            9041,
+            9042,
+            9043,
+            9044,
+            9045,
+            9046,
+            9047,
+            9048,
+            9049,
+            9050,
+            9051,
+            9052,
+            9053,
+            9054,
+            9055,
+            9056,
+            9057,
+            9058,
+            9059,
+            9060,
+            9061,
+            9062,
+            9063,
+            9064,
+            9065,
+            9066,
+            9067,
+            9068,
+            9069,
+            9070,
+            9071,
+            9072,
+            9073,
+            9074,
+            9075,
+            9076,
+            9077,
+            9078,
+            9079,
+            9080,
+            9081,
+            9082,
+            9083,
+            9084,
+            9085,
+            9086,
+            9087,
+            9088,
+            9089,
+            9090,
+            9091,
+            9092,
+            9093,
+            9094,
+            9095,
+            9096,
+            9097,
+            9098,
+            9099,
+            9100,
+            9101,
+            9102,
+            9103,
+            9104,
+            9105,
+            9106,
+            9107,
+            9108,
+            9109,
+            9110,
+            9111,
+            9112,
+            9113,
+            9114,
+            9115,
+            9116,
+            9117,
+            9118,
+            9119,
+            9120,
+            9121,
+            9122,
+            9123,
+            9124,
+            9125,
+            9126,
+            9127,
+            9128,
+            9129,
+            9130,
+            9131,
+            9132,
+            9133,
+            9134,
+            9135,
+            9136,
+            9137,
+            9138,
+            9139,
+            9140,
+            9141,
+            9142,
+            9143,
+            9144,
+            9145,
+            9146,
+            9147,
+            9148,
+            9149,
+            9150,
+            9151,
+            9152,
+            9153,
+            9154,
+            9155,
+            9156,
+            9157,
+            9158,
+            9159,
+            9160,
+            9161,
+            9162,
+            9163,
+            9164,
+            9165,
+            9166,
+            9167,
+            9168,
+            9169,
+            9170,
+            9171,
+            9172,
+            9173,
+            9174,
+            9175,
+            9176,
+            9177,
+            9178,
+            9179,
+            9180,
+            9181,
+            9182,
+            9183,
+            9184,
+            9185,
+            9186,
+            9187,
+            9188,
+            9189,
+            9190,
+            9191,
+            9192,
+            9193,
+            9194,
+            9195,
+            9196,
+            9197,
+            9198,
+            9199,
+            9200,
+            9201,
+            9202,
+            9203,
+            9204,
+            9205,
+            9206,
+            9207,
+            9208,
+            9209,
+            9210,
+            9211,
+            9212,
+            9213,
+            9214,
+            9215,
+            9216,
+            9217,
+            9218,
+            9219,
+            9220,
+            9221,
+            9222,
+            9223,
+            9224,
+            9225,
+            9226,
+            9227,
+            9228,
+            9229,
+            9230,
+            9231,
+            9232,
+            9233,
+            9234,
+            9235,
+            9236,
+            9237,
+            9238,
+            9239,
+            9240,
+            9241,
+            9242,
+            9243,
+            9244,
+            9245,
+            9246,
+            9247,
+            9248,
+            9249,
+            9250,
+            9251,
+            9252,
+            9253,
+            9254,
+            9255,
+            9256,
+            9257,
+            9258,
+            9259,
+            9260,
+            9261,
+            9262,
+            9263,
+            9264,
+            9265,
+            9266,
+            9267,
+            9268,
+            9269,
+            9270,
+            9271,
+            9272,
+            9273,
+            9274,
+            9275,
+            9276,
+            9277,
+            9278,
+            9279,
+            9280,
+            9281
+        ],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "desktop",
+        "categories": [
+            7,
+            43,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 898
+},
+{
+    "fields": {
+        "pkgname": "gnome-weather",
+        "type_id": "org.gnome.Weather.Application.desktop",
+        "keywords": [
+            9282,
+            9283,
+            9284,
+            9285,
+            9286,
+            9287,
+            9288,
+            9289,
+            9290,
+            9291,
+            9292,
+            9293,
+            9294,
+            9295,
+            9296,
+            9297,
+            9298,
+            9299,
+            9300,
+            9301,
+            9302,
+            9303,
+            9304,
+            9305,
+            9306,
+            9307,
+            9308,
+            9309,
+            9310,
+            9311,
+            9312,
+            9313,
+            9314,
+            9315,
+            9316,
+            9317,
+            9318,
+            9319,
+            9320,
+            9321,
+            9322,
+            9323,
+            9324,
+            9325,
+            9326,
+            9327,
+            9328,
+            9329,
+            9330,
+            9331,
+            9332,
+            9333,
+            9334,
+            9335,
+            9336,
+            9337,
+            9338,
+            9339,
+            9340,
+            9341,
+            9342,
+            9343,
+            9344,
+            9345,
+            9346,
+            9347,
+            9348,
+            9349,
+            9350,
+            9351,
+            9352,
+            9353,
+            9354,
+            9355,
+            9356,
+            9357,
+            9358,
+            9359,
+            9360,
+            9361
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+ AND MIT AND CC-BY-3.0 AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            5,
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 899
+},
+{
+    "fields": {
+        "pkgname": "baobab",
+        "type_id": "org.gnome.baobab.desktop",
+        "keywords": [
+            362,
+            422,
+            582,
+            950,
+            2320,
+            3306,
+            3386,
+            4819,
+            5528,
+            5542,
+            6281,
+            8379,
+            9362,
+            9363,
+            9364,
+            9365,
+            9366,
+            9367,
+            9368,
+            9369,
+            9370,
+            9371,
+            9372,
+            9373,
+            9374,
+            9375,
+            9376,
+            9377,
+            9378,
+            9379,
+            9380,
+            9381,
+            9382,
+            9383,
+            9384,
+            9385,
+            9386,
+            9387,
+            9388,
+            9389,
+            9390,
+            9391,
+            9392,
+            9393,
+            9394,
+            9395,
+            9396,
+            9397,
+            9398,
+            9399,
+            9400,
+            9401,
+            9402,
+            9403,
+            9404,
+            9405,
+            9406,
+            9407,
+            9408,
+            9409,
+            9410,
+            9411,
+            9412,
+            9413,
+            9414,
+            9415,
+            9416,
+            9417,
+            9418,
+            9419,
+            9420,
+            9421,
+            9422,
+            9423,
+            9424,
+            9425,
+            9426,
+            9427,
+            9428,
+            9429,
+            9430,
+            9431,
+            9432,
+            9433,
+            9434,
+            9435,
+            9436,
+            9437,
+            9438,
+            9439,
+            9440,
+            9441,
+            9442,
+            9443,
+            9444,
+            9445,
+            9446,
+            9447,
+            9448,
+            9449,
+            9450,
+            9451,
+            9452,
+            9453,
+            9454,
+            9455,
+            9456,
+            9457,
+            9458,
+            9459,
+            9460,
+            9461,
+            9462,
+            9463,
+            9464,
+            9465,
+            9466,
+            9467,
+            9468,
+            9469,
+            9470,
+            9471,
+            9472,
+            9473,
+            9474,
+            9475,
+            9476,
+            9477,
+            9478,
+            9479,
+            9480,
+            9481,
+            9482,
+            9483,
+            9484,
+            9485,
+            9486,
+            9487,
+            9488,
+            9489,
+            9490,
+            9491,
+            9492,
+            9493,
+            9494,
+            9495,
+            9496,
+            9497,
+            9498,
+            9499,
+            9500,
+            9501,
+            9502,
+            9503,
+            9504,
+            9505,
+            9506,
+            9507,
+            9508,
+            9509,
+            9510,
+            9511,
+            9512,
+            9513,
+            9514,
+            9515,
+            9516,
+            9517,
+            9518,
+            9519,
+            9520,
+            9521,
+            9522,
+            9523,
+            9524,
+            9525,
+            9526,
+            9527,
+            9528,
+            9529,
+            9530,
+            9531,
+            9532,
+            9533,
+            9534,
+            9535,
+            9536,
+            9537,
+            9538,
+            9539,
+            9540,
+            9541,
+            9542,
+            9543,
+            9544,
+            9545,
+            9546,
+            9547,
+            9548,
+            9549,
+            9550,
+            9551,
+            9552,
+            9553,
+            9554,
+            9555,
+            9556,
+            9557,
+            9558,
+            9559,
+            9560,
+            9561,
+            9562
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            4,
+            99
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 900
+},
+{
+    "fields": {
+        "pkgname": "gnome-clocks",
+        "type_id": "org.gnome.clocks.desktop",
+        "keywords": [
+            6582,
+            7174,
+            7183,
+            8116,
+            8117,
+            8122,
+            8131,
+            8132,
+            9348,
+            9351,
+            9563,
+            9564,
+            9565,
+            9566,
+            9567,
+            9568,
+            9569,
+            9570,
+            9571,
+            9572,
+            9573,
+            9574,
+            9575,
+            9576,
+            9577,
+            9578,
+            9579,
+            9580,
+            9581,
+            9582,
+            9583,
+            9584,
+            9585,
+            9586,
+            9587,
+            9588,
+            9589,
+            9590,
+            9591,
+            9592,
+            9593,
+            9594,
+            9595,
+            9596,
+            9597,
+            9598,
+            9599,
+            9600,
+            9601,
+            9602,
+            9603,
+            9604,
+            9605,
+            9606,
+            9607,
+            9608,
+            9609,
+            9610,
+            9611,
+            9612,
+            9613,
+            9614,
+            9615,
+            9616,
+            9617,
+            9618,
+            9619,
+            9620,
+            9621,
+            9622,
+            9623,
+            9624,
+            9625,
+            9626,
+            9627,
+            9628,
+            9629,
+            9630,
+            9631,
+            9632,
+            9633,
+            9634,
+            9635,
+            9636,
+            9637,
+            9638,
+            9639,
+            9640,
+            9641,
+            9642,
+            9643,
+            9644,
+            9645,
+            9646,
+            9647,
+            9648,
+            9649,
+            9650,
+            9651,
+            9652,
+            9653,
+            9654,
+            9655,
+            9656,
+            9657,
+            9658,
+            9659,
+            9660,
+            9661,
+            9662,
+            9663,
+            9664,
+            9665,
+            9666,
+            9667,
+            9668,
+            9669,
+            9670,
+            9671,
+            9672,
+            9673,
+            9674,
+            9675,
+            9676,
+            9677,
+            9678,
+            9679,
+            9680,
+            9681,
+            9682,
+            9683,
+            9684,
+            9685,
+            9686,
+            9687,
+            9688,
+            9689,
+            9690,
+            9691,
+            9692,
+            9693,
+            9694,
+            9695,
+            9696,
+            9697,
+            9698,
+            9699,
+            9700,
+            9701,
+            9702,
+            9703,
+            9704,
+            9705,
+            9706,
+            9707,
+            9708,
+            9709,
+            9710,
+            9711,
+            9712,
+            9713,
+            9714,
+            9715,
+            9716,
+            9717,
+            9718,
+            9719,
+            9720,
+            9721,
+            9722,
+            9723,
+            9724,
+            9725,
+            9726,
+            9727,
+            9728,
+            9729,
+            9730,
+            9731,
+            9732,
+            9733,
+            9734,
+            9735,
+            9736,
+            9737,
+            9738,
+            9739,
+            9740,
+            9741,
+            9742,
+            9743,
+            9744,
+            9745,
+            9746,
+            9747,
+            9748,
+            9749,
+            9750,
+            9751,
+            9752,
+            9753,
+            9754,
+            9755,
+            9756,
+            9757,
+            9758,
+            9759,
+            9760,
+            9761,
+            9762,
+            9763,
+            9764,
+            9765,
+            9766,
+            9767,
+            9768,
+            9769,
+            9770,
+            9771,
+            9772,
+            9773,
+            9774,
+            9775,
+            9776,
+            9777,
+            9778,
+            9779,
+            9780,
+            9781,
+            9782,
+            9783,
+            9784,
+            9785,
+            9786,
+            9787,
+            9788,
+            9789,
+            9790,
+            9791,
+            9792,
+            9793,
+            9794,
+            9795,
+            9796,
+            9797,
+            9798,
+            9799,
+            9800,
+            9801,
+            9802,
+            9803,
+            9804,
+            9805,
+            9806,
+            9807,
+            9808,
+            9809,
+            9810,
+            9811,
+            9812,
+            9813,
+            9814,
+            9815,
+            9816,
+            9817,
+            9818,
+            9819,
+            9820,
+            9821,
+            9822,
+            9823,
+            9824,
+            9825,
+            9826,
+            9827,
+            9828,
+            9829,
+            9830,
+            9831,
+            9832,
+            9833,
+            9834,
+            9835,
+            9836,
+            9837,
+            9838,
+            9839,
+            9840,
+            9841,
+            9842,
+            9843,
+            9844,
+            9845,
+            9846,
+            9847,
+            9848,
+            9849,
+            9850,
+            9851,
+            9852,
+            9853,
+            9854,
+            9855,
+            9856,
+            9857,
+            9858,
+            9859,
+            9860,
+            9861,
+            9862,
+            9863,
+            9864,
+            9865,
+            9866,
+            9867,
+            9868,
+            9869,
+            9870,
+            9871,
+            9872,
+            9873,
+            9874,
+            9875,
+            9876,
+            9877,
+            9878,
+            9879,
+            9880,
+            9881,
+            9882,
+            9883,
+            9884,
+            9885,
+            9886,
+            9887,
+            9888,
+            9889,
+            9890,
+            9891,
+            9892,
+            9893,
+            9894,
+            9895,
+            9896,
+            9897,
+            9898,
+            9899,
+            9900,
+            9901,
+            9902,
+            9903,
+            9904,
+            9905,
+            9906,
+            9907,
+            9908,
+            9909,
+            9910,
+            9911,
+            9912,
+            9913,
+            9914,
+            9915,
+            9916,
+            9917,
+            9918,
+            9919,
+            9920,
+            9921,
+            9922,
+            9923,
+            9924,
+            9925,
+            9926,
+            9927,
+            9928,
+            9929,
+            9930,
+            9931,
+            9932,
+            9933,
+            9934,
+            9935,
+            9936,
+            9937,
+            9938,
+            9939,
+            9940,
+            9941,
+            9942,
+            9943,
+            9944,
+            9945,
+            9946,
+            9947,
+            9948,
+            9949,
+            9950,
+            9951,
+            9952,
+            9953,
+            9954,
+            9955,
+            9956,
+            9957,
+            9958,
+            9959,
+            9960,
+            9961
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            34
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 901
+},
+{
+    "fields": {
+        "pkgname": "gnome-font-viewer",
+        "type_id": "org.gnome.font-viewer.desktop",
+        "keywords": [
+            2308,
+            5115,
+            5155,
+            5160,
+            5178,
+            5200,
+            5202,
+            5203,
+            5221,
+            5266,
+            5298,
+            5333,
+            5343,
+            5350,
+            5363,
+            5378,
+            5384,
+            5394,
+            5867,
+            5881,
+            5888,
+            5891,
+            5892,
+            5896,
+            5899,
+            5903,
+            5908,
+            5909,
+            5913,
+            5915,
+            5918,
+            5919,
+            5921,
+            5922,
+            5927,
+            5933,
+            5938,
+            5940,
+            5947,
+            5957,
+            5970,
+            5971,
+            5975,
+            5977,
+            5981,
+            5984,
+            6627,
+            9962,
+            9963,
+            9964,
+            9965,
+            9966,
+            9967,
+            9968,
+            9969,
+            9970,
+            9971,
+            9972,
+            9973,
+            9974,
+            9975,
+            9976,
+            9977,
+            9978,
+            9979,
+            9980,
+            9981,
+            9982,
+            9983,
+            9984,
+            9985,
+            9986,
+            9987,
+            9988,
+            9989,
+            9990,
+            9991,
+            9992,
+            9993,
+            9994,
+            9995,
+            9996,
+            9997,
+            9998,
+            9999,
+            10000,
+            10001,
+            10002,
+            10003,
+            10004,
+            10005,
+            10006,
+            10007,
+            10008,
+            10009,
+            10010,
+            10011,
+            10012,
+            10013,
+            10014,
+            10015,
+            10016,
+            10017,
+            10018,
+            10019,
+            10020,
+            10021,
+            10022,
+            10023,
+            10024,
+            10025,
+            10026,
+            10027,
+            10028,
+            10029,
+            10030,
+            10031,
+            10032,
+            10033,
+            10034,
+            10035,
+            10036,
+            10037,
+            10038,
+            10039,
+            10040,
+            10041,
+            10042,
+            10043,
+            10044,
+            10045,
+            10046,
+            10047,
+            10048,
+            10049,
+            10050,
+            10051,
+            10052,
+            10053,
+            10054,
+            10055,
+            10056,
+            10057,
+            10058,
+            10059,
+            10060,
+            10061,
+            10062,
+            10063,
+            10064,
+            10065
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 902
+},
+{
+    "fields": {
+        "pkgname": "gedit",
+        "type_id": "org.gnome.gedit.desktop",
+        "keywords": [
+            2567,
+            2927,
+            6091,
+            6092,
+            6094,
+            6095,
+            6096,
+            6110,
+            6111,
+            6115,
+            6116,
+            6158,
+            7106,
+            10055,
+            10057,
+            10066,
+            10067,
+            10068,
+            10069,
+            10070,
+            10071,
+            10072,
+            10073,
+            10074,
+            10075,
+            10076,
+            10077,
+            10078,
+            10079,
+            10080,
+            10081,
+            10082,
+            10083,
+            10084,
+            10085,
+            10086,
+            10087,
+            10088,
+            10089,
+            10090,
+            10091,
+            10092,
+            10093,
+            10094,
+            10095,
+            10096,
+            10097,
+            10098,
+            10099,
+            10100,
+            10101,
+            10102,
+            10103,
+            10104,
+            10105,
+            10106,
+            10107,
+            10108,
+            10109,
+            10110,
+            10111,
+            10112,
+            10113,
+            10114,
+            10115,
+            10116,
+            10117,
+            10118,
+            10119,
+            10120,
+            10121,
+            10122,
+            10123,
+            10124,
+            10125,
+            10126,
+            10127,
+            10128,
+            10129,
+            10130,
+            10131,
+            10132,
+            10133,
+            10134,
+            10135,
+            10136,
+            10137,
+            10138,
+            10139,
+            10140,
+            10141,
+            10142,
+            10143,
+            10144,
+            10145,
+            10146,
+            10147,
+            10148,
+            10149,
+            10150,
+            10151,
+            10152,
+            10153,
+            10154,
+            10155,
+            10156,
+            10157,
+            10158,
+            10159,
+            10160,
+            10161,
+            10162,
+            10163,
+            10164,
+            10165,
+            10166,
+            10167,
+            10168,
+            10169,
+            10170,
+            10171,
+            10172,
+            10173,
+            10174,
+            10175,
+            10176,
+            10177,
+            10178,
+            10179,
+            10180,
+            10181,
+            10182,
+            10183,
+            10184,
+            10185
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 903
+},
+{
+    "fields": {
+        "pkgname": "gnome-taquin",
+        "type_id": "org.gnome.taquin.desktop",
+        "keywords": [
+            709,
+            710,
+            1912,
+            2180,
+            2189,
+            2678,
+            2679,
+            2680,
+            2681,
+            2682,
+            2683,
+            2684,
+            3786,
+            3789,
+            3791,
+            3798,
+            3802,
+            3805,
+            3808,
+            3810,
+            3816,
+            3822,
+            3823,
+            3834,
+            3838,
+            3840,
+            3844,
+            3850,
+            3855,
+            6000,
+            6001,
+            6006,
+            6016,
+            6031,
+            6033,
+            6037,
+            6182,
+            10186,
+            10187,
+            10188,
+            10189,
+            10190,
+            10191,
+            10192,
+            10193,
+            10194,
+            10195
+        ],
+        "project_license": "GPL-3.0+ AND GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 904
+},
+{
+    "fields": {
+        "pkgname": "nuntius",
+        "type_id": "org.holylobster.nuntius.desktop",
+        "keywords": [
+            10196,
+            10197,
+            10198,
+            10199,
+            10200,
+            10201,
+            10202,
+            10203,
+            10204,
+            10205,
+            10206,
+            10207,
+            10208,
+            10209,
+            10210,
+            10211
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 905
+},
+{
+    "fields": {
+        "pkgname": "kde-partitionmanager",
+        "type_id": "org.kde.PartitionManager.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            99
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 906
+},
+{
+    "fields": {
+        "pkgname": "blinken",
+        "type_id": "org.kde.blinken.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            19,
+            106
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 907
+},
+{
+    "fields": {
+        "pkgname": "filelight",
+        "type_id": "org.kde.filelight.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 OR GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 908
+},
+{
+    "fields": {
+        "pkgname": "kalgebra",
+        "type_id": "org.kde.kalgebra.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 909
+},
+{
+    "fields": {
+        "pkgname": "kanagram",
+        "type_id": "org.kde.kanagram.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            19,
+            46,
+            106
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 910
+},
+{
+    "fields": {
+        "pkgname": "kapman",
+        "type_id": "org.kde.kapman.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 911
+},
+{
+    "fields": {
+        "pkgname": "kate",
+        "type_id": "org.kde.kate.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1 AND LGPL-2.1+ AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 912
+},
+{
+    "fields": {
+        "pkgname": "kbruch",
+        "type_id": "org.kde.kbruch.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 913
+},
+{
+    "fields": {
+        "pkgname": "kgeography",
+        "type_id": "org.kde.kgeography.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            25
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 914
+},
+{
+    "fields": {
+        "pkgname": "khangman",
+        "type_id": "org.kde.khangman.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            19,
+            46,
+            106
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 915
+},
+{
+    "fields": {
+        "pkgname": "kiten",
+        "type_id": "org.kde.kiten.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            46
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 916
+},
+{
+    "fields": {
+        "pkgname": "klettres",
+        "type_id": "org.kde.klettres.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            46
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 917
+},
+{
+    "fields": {
+        "pkgname": "plasma-workspace",
+        "type_id": "org.kde.klipper.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 918
+},
+{
+    "fields": {
+        "pkgname": "kmplot",
+        "type_id": "org.kde.kmplot.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 919
+},
+{
+    "fields": {
+        "pkgname": "kollision",
+        "type_id": "org.kde.kollision.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 920
+},
+{
+    "fields": {
+        "pkgname": "konsole5",
+        "type_id": "org.kde.konsole.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 921
+},
+{
+    "fields": {
+        "pkgname": "kstars",
+        "type_id": "org.kde.kstars.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            69
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 922
+},
+{
+    "fields": {
+        "pkgname": "kteatime",
+        "type_id": "org.kde.kteatime.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 923
+},
+{
+    "fields": {
+        "pkgname": "kturtle",
+        "type_id": "org.kde.kturtle.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            114
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 924
+},
+{
+    "fields": {
+        "pkgname": "kwordquiz",
+        "type_id": "org.kde.kwordquiz.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            46
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 925
+},
+{
+    "fields": {
+        "pkgname": "kwrite",
+        "type_id": "org.kde.kwrite.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 926
+},
+{
+    "fields": {
+        "pkgname": "parley",
+        "type_id": "org.kde.parley.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            46
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 927
+},
+{
+    "fields": {
+        "pkgname": "step",
+        "type_id": "org.kde.step.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            20
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 928
+},
+{
+    "fields": {
+        "pkgname": "osmo",
+        "type_id": "osmo.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            67,
+            89
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 929
+},
+{
+    "fields": {
+        "pkgname": "otter-browser",
+        "type_id": "otter-browser.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            52
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 930
+},
+{
+    "fields": {
+        "pkgname": "overpass-fonts",
+        "type_id": "overpass",
+        "keywords": [],
+        "project_license": "OFL-1.1 OR Apache-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 931
+},
+{
+    "fields": {
+        "pkgname": "mirall",
+        "type_id": "owncloud.desktop",
+        "keywords": [
+            10212,
+            10213,
+            10214,
+            10215
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 932
+},
+{
+    "fields": {
+        "pkgname": "perl-Padre",
+        "type_id": "padre.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+ OR Artistic-1.0",
+        "type": "desktop",
+        "categories": [
+            11,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 933
+},
+{
+    "fields": {
+        "pkgname": "pagul-fonts",
+        "type_id": "pagul",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 934
+},
+{
+    "fields": {
+        "pkgname": "pairs",
+        "type_id": "pairs.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 OR GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            19,
+            106
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 935
+},
+{
+    "fields": {
+        "pkgname": "pan",
+        "type_id": "pan.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            24
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 936
+},
+{
+    "fields": {
+        "pkgname": "kipi-plugins",
+        "type_id": "panoramagui.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Adobe",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 937
+},
+{
+    "fields": {
+        "pkgname": "paratype-pt-mono-fonts",
+        "type_id": "paratype-pt-mono",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 938
+},
+{
+    "fields": {
+        "pkgname": "paratype-pt-sans-caption-fonts",
+        "type_id": "paratype-pt-sans",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 939
+},
+{
+    "fields": {
+        "pkgname": "paratype-pt-serif-caption-fonts",
+        "type_id": "paratype-pt-serif",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 940
+},
+{
+    "fields": {
+        "pkgname": "paraview-data",
+        "type_id": "paraview.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 941
+},
+{
+    "fields": {
+        "pkgname": "parcellite",
+        "type_id": "parcellite.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 942
+},
+{
+    "fields": {
+        "pkgname": "paulstretch",
+        "type_id": "paulstretch.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 943
+},
+{
+    "fields": {
+        "pkgname": "pavucontrol",
+        "type_id": "pavucontrol.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            115
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 944
+},
+{
+    "fields": {
+        "pkgname": "pcb",
+        "type_id": "pcb.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            16,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 945
+},
+{
+    "fields": {
+        "pkgname": "kicad",
+        "type_id": "pcbcalculator.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            16
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 946
+},
+{
+    "fields": {
+        "pkgname": "kicad",
+        "type_id": "pcbnew.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            16
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 947
+},
+{
+    "fields": {
+        "pkgname": "pcmanfm-qt",
+        "type_id": "pcmanfm-qt.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            3,
+            5,
+            30
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 948
+},
+{
+    "fields": {
+        "pkgname": "pcmanfm",
+        "type_id": "pcmanfm.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            3,
+            4,
+            5,
+            30,
+            33
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 949
+},
+{
+    "fields": {
+        "pkgname": "pcmanx-gtk2",
+        "type_id": "pcmanx.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            24,
+            82,
+            116
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 950
+},
+{
+    "fields": {
+        "pkgname": "pdfmod",
+        "type_id": "pdfmod.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 951
+},
+{
+    "fields": {
+        "pkgname": "pdfshuffler",
+        "type_id": "pdfshuffler.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 952
+},
+{
+    "fields": {
+        "pkgname": "peg-solitaire",
+        "type_id": "peg-solitaire.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 953
+},
+{
+    "fields": {
+        "pkgname": "phatch",
+        "type_id": "phatch.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            75
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 954
+},
+{
+    "fields": {
+        "pkgname": "phoronix-test-suite",
+        "type_id": "phoronix-test-suite.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 955
+},
+{
+    "fields": {
+        "pkgname": "photocollage",
+        "type_id": "photocollage.desktop",
+        "keywords": [
+            1584,
+            6636,
+            7955,
+            7956,
+            10216,
+            10217,
+            10218,
+            10219,
+            10220,
+            10221,
+            10222
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            71,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 956
+},
+{
+    "fields": {
+        "pkgname": "kipi-plugins",
+        "type_id": "photolayoutseditor.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Adobe",
+        "type": "desktop",
+        "categories": [
+            26,
+            75
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 957
+},
+{
+    "fields": {
+        "pkgname": "picard",
+        "type_id": "picard.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            56
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 958
+},
+{
+    "fields": {
+        "pkgname": "picmi",
+        "type_id": "picmi.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 959
+},
+{
+    "fields": {
+        "pkgname": "pidgin",
+        "type_id": "pidgin.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-2.0 AND MIT",
+        "type": "desktop",
+        "categories": [
+            23,
+            82
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 960
+},
+{
+    "fields": {
+        "pkgname": "piklab",
+        "type_id": "piklab.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            16
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 961
+},
+{
+    "fields": {
+        "pkgname": "pinta",
+        "type_id": "pinta.desktop",
+        "keywords": [],
+        "project_license": "MIT AND CC-BY-3.0",
+        "type": "desktop",
+        "categories": [
+            26,
+            71,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 962
+},
+{
+    "fields": {
+        "pkgname": "pioneers",
+        "type_id": "pioneers.desktop",
+        "keywords": [
+            198,
+            2171,
+            2183,
+            2203,
+            2220,
+            2224,
+            2246,
+            2947,
+            3768,
+            3803,
+            3820,
+            10223,
+            10224,
+            10225,
+            10226,
+            10227,
+            10228,
+            10229,
+            10230,
+            10231,
+            10232,
+            10233,
+            10234,
+            10235,
+            10236,
+            10237,
+            10238,
+            10239,
+            10240,
+            10241,
+            10242,
+            10243
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            60
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 963
+},
+{
+    "fields": {
+        "pkgname": "pitivi",
+        "type_id": "pitivi.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            7,
+            56,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 964
+},
+{
+    "fields": {
+        "pkgname": "calligra-plan",
+        "type_id": "plan.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 965
+},
+{
+    "fields": {
+        "pkgname": "plasma-mediacenter",
+        "type_id": "plasma-mediacenter.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 966
+},
+{
+    "fields": {
+        "pkgname": "plater",
+        "type_id": "plater.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND CC0-1.0",
+        "type": "desktop",
+        "categories": [
+            5,
+            26,
+            61
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 967
+},
+{
+    "fields": {
+        "pkgname": "plee-the-bear",
+        "type_id": "plee-the-bear.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 968
+},
+{
+    "fields": {
+        "pkgname": "plotdrop",
+        "type_id": "plotdrop.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 969
+},
+{
+    "fields": {
+        "pkgname": "pluma",
+        "type_id": "pluma.desktop",
+        "keywords": [
+            184,
+            312,
+            720,
+            796,
+            6083,
+            10244,
+            10245,
+            10246,
+            10247
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 970
+},
+{
+    "fields": {
+        "pkgname": "poedit",
+        "type_id": "poedit.desktop",
+        "keywords": [
+            10248,
+            10249,
+            10250
+        ],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            11,
+            104
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 971
+},
+{
+    "fields": {
+        "pkgname": "pogo",
+        "type_id": "pogo.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 972
+},
+{
+    "fields": {
+        "pkgname": "pokerth",
+        "type_id": "pokerth.desktop",
+        "keywords": [],
+        "project_license": "AGPL-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            107
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 973
+},
+{
+    "fields": {
+        "pkgname": "pondus",
+        "type_id": "pondus.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 974
+},
+{
+    "fields": {
+        "pkgname": "pothana2000-fonts",
+        "type_id": "pothana2000",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 975
+},
+{
+    "fields": {
+        "pkgname": "pragha",
+        "type_id": "pragha.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 976
+},
+{
+    "fields": {
+        "pkgname": "prepaid-manager-applet",
+        "type_id": "prepaid-manager-applet.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 977
+},
+{
+    "fields": {
+        "pkgname": "presence",
+        "type_id": "presence.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 978
+},
+{
+    "fields": {
+        "pkgname": "proguard-gui",
+        "type_id": "proguard.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            49
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 979
+},
+{
+    "fields": {
+        "pkgname": "pronsole",
+        "type_id": "pronsole.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND CC0-1.0",
+        "type": "desktop",
+        "categories": [
+            5,
+            26,
+            61,
+            63
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 980
+},
+{
+    "fields": {
+        "pkgname": "pronterface",
+        "type_id": "pronterface.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND CC0-1.0",
+        "type": "desktop",
+        "categories": [
+            5,
+            26,
+            61
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 981
+},
+{
+    "fields": {
+        "pkgname": "emacs-common-proofgeneral",
+        "type_id": "proofgeneral.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            5,
+            11,
+            19,
+            21,
+            27,
+            32,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 982
+},
+{
+    "fields": {
+        "pkgname": "psi",
+        "type_id": "psi.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            82
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 983
+},
+{
+    "fields": {
+        "pkgname": "pspp",
+        "type_id": "pspp.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 984
+},
+{
+    "fields": {
+        "pkgname": "pulsecaster",
+        "type_id": "pulsecaster.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 985
+},
+{
+    "fields": {
+        "pkgname": "pulseview",
+        "type_id": "pulseview.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            16
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 986
+},
+{
+    "fields": {
+        "pkgname": "putty",
+        "type_id": "putty.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            23,
+            95
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 987
+},
+{
+    "fields": {
+        "pkgname": "pybliographer",
+        "type_id": "pybliographic.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            13,
+            40
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 988
+},
+{
+    "fields": {
+        "pkgname": "pycam",
+        "type_id": "pycam.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            19,
+            21,
+            61,
+            83,
+            84,
+            88,
+            93
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 989
+},
+{
+    "fields": {
+        "pkgname": "pychess",
+        "type_id": "pychess.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            60
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 990
+},
+{
+    "fields": {
+        "pkgname": "pyhoca-gui",
+        "type_id": "pyhoca-gui.desktop",
+        "keywords": [
+            803,
+            804,
+            10251,
+            10252,
+            10253,
+            10254,
+            10255
+        ],
+        "project_license": "AGPL-3.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            95
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 991
+},
+{
+    "fields": {
+        "pkgname": "pyqtrailer",
+        "type_id": "pyqtrailer.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            7,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 992
+},
+{
+    "fields": {
+        "pkgname": "qbittorrent",
+        "type_id": "qBittorrent.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            76,
+            77
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 993
+},
+{
+    "fields": {
+        "pkgname": "qalculate-kde",
+        "type_id": "qalculate_kde.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 994
+},
+{
+    "fields": {
+        "pkgname": "qasconfig",
+        "type_id": "qasconfig.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            115
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 995
+},
+{
+    "fields": {
+        "pkgname": "qashctl",
+        "type_id": "qashctl.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            115
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 996
+},
+{
+    "fields": {
+        "pkgname": "qasmixer",
+        "type_id": "qasmixer.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            115
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 997
+},
+{
+    "fields": {
+        "pkgname": "qcomicbook",
+        "type_id": "qcomicbook.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            14,
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 998
+},
+{
+    "fields": {
+        "pkgname": "qdevelop",
+        "type_id": "qdevelop.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 999
+},
+{
+    "fields": {
+        "pkgname": "qdigidoc",
+        "type_id": "qdigidoc-client.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1000
+},
+{
+    "fields": {
+        "pkgname": "qelectrotech",
+        "type_id": "qelectrotech.desktop",
+        "keywords": [
+            1368,
+            10256,
+            10257,
+            10258
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            16,
+            21,
+            26,
+            83,
+            88,
+            117
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1001
+},
+{
+    "fields": {
+        "pkgname": "qesteidutil",
+        "type_id": "qesteidutil.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1002
+},
+{
+    "fields": {
+        "pkgname": "qgit",
+        "type_id": "qgit.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            11,
+            94
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1003
+},
+{
+    "fields": {
+        "pkgname": "qmidiarp",
+        "type_id": "qmidiarp.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            56,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1004
+},
+{
+    "fields": {
+        "pkgname": "qmmp",
+        "type_id": "qmmp.desktop",
+        "keywords": [
+            339,
+            344,
+            3257,
+            6689,
+            10259,
+            10260,
+            10261
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1005
+},
+{
+    "fields": {
+        "pkgname": "qpdfview",
+        "type_id": "qpdfview.desktop",
+        "keywords": [
+            186,
+            187,
+            189,
+            191,
+            193,
+            1732
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            14
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1006
+},
+{
+    "fields": {
+        "pkgname": "qstardict",
+        "type_id": "qstardict.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            59
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1007
+},
+{
+    "fields": {
+        "pkgname": "qt-assistant",
+        "type_id": "qt4-assistant.desktop",
+        "keywords": [],
+        "project_license": "(LGPL-2.0 OR GPL-3.0-with-GCC-exception) AND Apache-2.0 AND BSD-3-Clause AND FTL AND MIT",
+        "type": "desktop",
+        "categories": [
+            11,
+            85
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1008
+},
+{
+    "fields": {
+        "pkgname": "qt-devel",
+        "type_id": "qt4-designer.desktop",
+        "keywords": [],
+        "project_license": "(LGPL-2.0 OR GPL-3.0-with-GCC-exception) AND Apache-2.0 AND BSD-3-Clause AND FTL AND MIT",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1009
+},
+{
+    "fields": {
+        "pkgname": "qt-qdbusviewer",
+        "type_id": "qt4-qdbusviewer.desktop",
+        "keywords": [],
+        "project_license": "(LGPL-2.0 OR GPL-3.0-with-GCC-exception) AND Apache-2.0 AND BSD-3-Clause AND FTL AND MIT",
+        "type": "desktop",
+        "categories": [
+            11,
+            42
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1010
+},
+{
+    "fields": {
+        "pkgname": "qt5-assistant",
+        "type_id": "qt5-assistant.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.0 OR GPL-3.0-with-GCC-exception",
+        "type": "desktop",
+        "categories": [
+            11,
+            85
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1011
+},
+{
+    "fields": {
+        "pkgname": "qt5-qttools-devel",
+        "type_id": "qt5-designer.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.0 OR GPL-3.0-with-GCC-exception",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1012
+},
+{
+    "fields": {
+        "pkgname": "qt5-qttools-devel",
+        "type_id": "qt5-linguist.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.0 OR GPL-3.0-with-GCC-exception",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1013
+},
+{
+    "fields": {
+        "pkgname": "qt5-qdbusviewer",
+        "type_id": "qt5-qdbusviewer.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.0 OR GPL-3.0-with-GCC-exception",
+        "type": "desktop",
+        "categories": [
+            11,
+            42
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1014
+},
+{
+    "fields": {
+        "pkgname": "qt-creator",
+        "type_id": "qtcreator.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1 OR LGPLv3, with exceptions",
+        "type": "desktop",
+        "categories": [
+            11,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1015
+},
+{
+    "fields": {
+        "pkgname": "qtdbf",
+        "type_id": "qtdbf.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            40
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1016
+},
+{
+    "fields": {
+        "pkgname": "qterm",
+        "type_id": "qterm.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            95
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1017
+},
+{
+    "fields": {
+        "pkgname": "qterminal",
+        "type_id": "qterminal.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1018
+},
+{
+    "fields": {
+        "pkgname": "qtgpsc",
+        "type_id": "qtgpsc.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1019
+},
+{
+    "fields": {
+        "pkgname": "qtoctave",
+        "type_id": "qtoctave.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1020
+},
+{
+    "fields": {
+        "pkgname": "qtractor",
+        "type_id": "qtractor.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            78,
+            105
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1021
+},
+{
+    "fields": {
+        "pkgname": "quadrapassel",
+        "type_id": "quadrapassel.desktop",
+        "keywords": [
+            2183,
+            10262,
+            10263,
+            10264,
+            10265,
+            10266,
+            10267,
+            10268,
+            10269,
+            10270,
+            10271,
+            10272,
+            10273,
+            10274,
+            10275,
+            10276,
+            10277,
+            10278,
+            10279,
+            10280,
+            10281,
+            10282,
+            10283,
+            10284,
+            10285,
+            10286,
+            10287
+        ],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            10
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1022
+},
+{
+    "fields": {
+        "pkgname": "quassel",
+        "type_id": "quassel.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 OR GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            70,
+            116
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1023
+},
+{
+    "fields": {
+        "pkgname": "quearcode",
+        "type_id": "quearcode.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1024
+},
+{
+    "fields": {
+        "pkgname": "ibus-cangjie-engine-quick",
+        "type_id": "quick.xml",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1025
+},
+{
+    "fields": {
+        "pkgname": "quitcount",
+        "type_id": "quitcount.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1026
+},
+{
+    "fields": {
+        "pkgname": "quiterss",
+        "type_id": "quiterss.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            24
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1027
+},
+{
+    "fields": {
+        "pkgname": "quodlibet",
+        "type_id": "quodlibet.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1028
+},
+{
+    "fields": {
+        "pkgname": "qupzilla",
+        "type_id": "qupzilla.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            23,
+            52
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1029
+},
+{
+    "fields": {
+        "pkgname": "qutim",
+        "type_id": "qutim.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            82
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1030
+},
+{
+    "fields": {
+        "pkgname": "qv4l2",
+        "type_id": "qv4l2.desktop",
+        "keywords": [
+            344,
+            10288,
+            10289
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1031
+},
+{
+    "fields": {
+        "pkgname": "rafkill",
+        "type_id": "rafkill.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1032
+},
+{
+    "fields": {
+        "pkgname": "rakarrack",
+        "type_id": "rakarrack.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            115
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1033
+},
+{
+    "fields": {
+        "pkgname": "rapid-photo-downloader",
+        "type_id": "rapid-photo-downloader.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            75
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1034
+},
+{
+    "fields": {
+        "pkgname": "rasmol",
+        "type_id": "rasmol.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            18,
+            21,
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1035
+},
+{
+    "fields": {
+        "pkgname": "rawtherapee",
+        "type_id": "rawtherapee.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0 AND MIT AND IJG",
+        "type": "desktop",
+        "categories": [
+            26,
+            71,
+            75,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1036
+},
+{
+    "fields": {
+        "pkgname": "rcssserver3d",
+        "type_id": "rcssserver3d.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            93
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1037
+},
+{
+    "fields": {
+        "pkgname": "recoll",
+        "type_id": "recoll-searchgui.desktop",
+        "keywords": [
+            10290,
+            10291
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            40,
+            99
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1038
+},
+{
+    "fields": {
+        "pkgname": "redeclipse",
+        "type_id": "redeclipse.desktop",
+        "keywords": [],
+        "project_license": "Zlib AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1039
+},
+{
+    "fields": {
+        "pkgname": "rednotebook",
+        "type_id": "rednotebook.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            67
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1040
+},
+{
+    "fields": {
+        "pkgname": "redshift-gtk",
+        "type_id": "redshift-gtk.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1041
+},
+{
+    "fields": {
+        "pkgname": "reinteract",
+        "type_id": "reinteract.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            19,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1042
+},
+{
+    "fields": {
+        "pkgname": "remmina",
+        "type_id": "remmina.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND MIT",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1043
+},
+{
+    "fields": {
+        "pkgname": "repsnapper",
+        "type_id": "repsnapper.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND MIT AND softSurfer AND CC-BY-3.0",
+        "type": "desktop",
+        "categories": [
+            26,
+            83
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1044
+},
+{
+    "fields": {
+        "pkgname": "retext",
+        "type_id": "retext.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            37
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1045
+},
+{
+    "fields": {
+        "pkgname": "revelation",
+        "type_id": "revelation.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1046
+},
+{
+    "fields": {
+        "pkgname": "revisor-gui",
+        "type_id": "revisor.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            50
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1047
+},
+{
+    "fields": {
+        "pkgname": "rhythmbox",
+        "type_id": "rhythmbox.desktop",
+        "keywords": [
+            351,
+            353,
+            414,
+            453,
+            459,
+            460,
+            461,
+            536,
+            541,
+            549,
+            579,
+            580,
+            583,
+            585,
+            589,
+            593,
+            1094,
+            1095,
+            1096,
+            1100,
+            3936,
+            3957,
+            3960,
+            3976,
+            5745,
+            5818,
+            8630,
+            8636,
+            8641,
+            8651,
+            8667,
+            8681,
+            8684,
+            8691,
+            8698,
+            8699,
+            8701,
+            8703,
+            8705,
+            8714,
+            8720,
+            8728,
+            8732,
+            10292,
+            10293,
+            10294,
+            10295,
+            10296,
+            10297,
+            10298,
+            10299,
+            10300,
+            10301,
+            10302,
+            10303,
+            10304,
+            10305,
+            10306,
+            10307,
+            10308,
+            10309,
+            10310,
+            10311,
+            10312,
+            10313,
+            10314,
+            10315,
+            10316,
+            10317,
+            10318,
+            10319,
+            10320,
+            10321,
+            10322,
+            10323,
+            10324,
+            10325,
+            10326,
+            10327,
+            10328,
+            10329,
+            10330,
+            10331,
+            10332,
+            10333,
+            10334,
+            10335,
+            10336,
+            10337,
+            10338,
+            10339,
+            10340,
+            10341,
+            10342,
+            10343,
+            10344,
+            10345,
+            10346,
+            10347,
+            10348,
+            10349,
+            10350,
+            10351,
+            10352,
+            10353,
+            10354,
+            10355,
+            10356,
+            10357,
+            10358,
+            10359,
+            10360,
+            10361,
+            10362,
+            10363,
+            10364,
+            10365,
+            10366,
+            10367,
+            10368,
+            10369,
+            10370,
+            10371,
+            10372,
+            10373,
+            10374,
+            10375,
+            10376,
+            10377,
+            10378,
+            10379,
+            10380,
+            10381,
+            10382,
+            10383,
+            10384,
+            10385,
+            10386,
+            10387,
+            10388,
+            10389,
+            10390,
+            10391,
+            10392,
+            10393,
+            10394,
+            10395,
+            10396,
+            10397,
+            10398,
+            10399,
+            10400,
+            10401,
+            10402,
+            10403,
+            10404,
+            10405,
+            10406,
+            10407,
+            10408,
+            10409,
+            10410,
+            10411,
+            10412,
+            10413,
+            10414,
+            10415,
+            10416,
+            10417,
+            10418,
+            10419,
+            10420,
+            10421,
+            10422,
+            10423,
+            10424,
+            10425,
+            10426,
+            10427,
+            10428,
+            10429,
+            10430,
+            10431,
+            10432,
+            10433,
+            10434,
+            10435,
+            10436,
+            10437,
+            10438,
+            10439,
+            10440,
+            10441,
+            10442,
+            10443,
+            10444,
+            10445,
+            10446,
+            10447,
+            10448,
+            10449,
+            10450,
+            10451,
+            10452,
+            10453,
+            10454,
+            10455,
+            10456,
+            10457,
+            10458,
+            10459,
+            10460,
+            10461,
+            10462,
+            10463,
+            10464,
+            10465,
+            10466,
+            10467,
+            10468,
+            10469,
+            10470,
+            10471,
+            10472,
+            10473,
+            10474,
+            10475,
+            10476,
+            10477,
+            10478,
+            10479,
+            10480
+        ],
+        "project_license": "GPL-2.0-with-font-exception AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1048
+},
+{
+    "fields": {
+        "pkgname": "ristretto",
+        "type_id": "ristretto.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1049
+},
+{
+    "fields": {
+        "pkgname": "rkward",
+        "type_id": "rkward-open.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            21,
+            27,
+            110
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1050
+},
+{
+    "fields": {
+        "pkgname": "rkward",
+        "type_id": "rkward.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            21,
+            27,
+            110
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1051
+},
+{
+    "fields": {
+        "pkgname": "rocksndiamonds",
+        "type_id": "rocksndiamonds.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1052
+},
+{
+    "fields": {
+        "pkgname": "rocs",
+        "type_id": "rocs.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1053
+},
+{
+    "fields": {
+        "pkgname": "root",
+        "type_id": "root.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1054
+},
+{
+    "fields": {
+        "pkgname": "rosegarden4",
+        "type_id": "rosegarden.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            78,
+            105
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1055
+},
+{
+    "fields": {
+        "pkgname": "roxterm",
+        "type_id": "roxterm.desktop",
+        "keywords": [
+            8733,
+            8734,
+            8735,
+            8736,
+            8737,
+            8738,
+            8739,
+            8740,
+            8741,
+            8742,
+            8743,
+            8744,
+            8745,
+            8746,
+            8747,
+            8748,
+            8749,
+            8750,
+            8751,
+            8771,
+            8772,
+            8773,
+            8774,
+            8775,
+            8776,
+            8777,
+            8778,
+            8779,
+            8780,
+            8781,
+            8782,
+            8783,
+            8784,
+            8785,
+            8786,
+            8787,
+            8788,
+            8789,
+            8790,
+            8791,
+            8792,
+            8793,
+            8794,
+            8795,
+            8796,
+            8797,
+            8798,
+            8799,
+            8800,
+            8801,
+            8802,
+            8803,
+            8804,
+            8805,
+            8806,
+            8807,
+            8808,
+            8809,
+            8810,
+            8811,
+            8820,
+            8821,
+            8822,
+            8823,
+            8824,
+            8825,
+            8826,
+            8827,
+            8828,
+            8829,
+            8830,
+            8831,
+            8832,
+            8833,
+            8834,
+            8835,
+            8836,
+            8837,
+            8838,
+            8839,
+            8840,
+            8841,
+            8842,
+            8843,
+            8844,
+            8845,
+            8847,
+            8848,
+            8849,
+            8859,
+            8860,
+            8861,
+            8862,
+            8863,
+            8864,
+            8865,
+            8866,
+            8867,
+            8868,
+            8869,
+            8870,
+            8871,
+            8872,
+            8873,
+            8874,
+            8875,
+            8876,
+            8877,
+            8878,
+            8879,
+            8880,
+            8881,
+            8882,
+            8883,
+            8884,
+            8885,
+            8886,
+            8887,
+            8888,
+            8889,
+            8890,
+            8891,
+            8892,
+            8893,
+            8894,
+            8895,
+            8896,
+            8897,
+            8898,
+            8899,
+            8900,
+            8901,
+            8902,
+            8903,
+            8904,
+            8905,
+            8906,
+            8907,
+            8908,
+            8909,
+            8910,
+            8911,
+            8912,
+            8913,
+            8914,
+            8915,
+            8916,
+            8917,
+            8918,
+            8919,
+            8920,
+            8921,
+            8922,
+            8923,
+            8924,
+            8925,
+            8926,
+            8927,
+            8928,
+            8929,
+            8930,
+            8934,
+            8935,
+            8936,
+            8937,
+            8938,
+            8939,
+            8940,
+            8941,
+            8942,
+            8943,
+            8944,
+            8945,
+            8946,
+            8947,
+            8948,
+            8949,
+            8954,
+            8955,
+            8956,
+            8957,
+            8960,
+            8966,
+            8967,
+            8968,
+            8969,
+            8970,
+            8971,
+            8972,
+            8973,
+            8974,
+            10481,
+            10482,
+            10483,
+            10484,
+            10485
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1056
+},
+{
+    "fields": {
+        "pkgname": "rsibreak",
+        "type_id": "rsibreak.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1057
+},
+{
+    "fields": {
+        "pkgname": "rxvt-unicode",
+        "type_id": "rxvt-unicode.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1058
+},
+{
+    "fields": {
+        "pkgname": "saga",
+        "type_id": "saga.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND LGPL-2.1",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            25
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1059
+},
+{
+    "fields": {
+        "pkgname": "sagemath",
+        "type_id": "sagemath.desktop",
+        "keywords": [],
+        "project_license": "Apache-2.0 AND BSD-3-Clause AND GPL-1.0+ AND GPL-2.0+ AND LGPL-2.1+ AND MIT AND Public Domain",
+        "type": "desktop",
+        "categories": [
+            21,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1060
+},
+{
+    "fields": {
+        "pkgname": "sailcut",
+        "type_id": "sailcut.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1061
+},
+{
+    "fields": {
+        "pkgname": "sakura",
+        "type_id": "sakura.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1062
+},
+{
+    "fields": {
+        "pkgname": "samplv1",
+        "type_id": "samplv1.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1063
+},
+{
+    "fields": {
+        "pkgname": "samyak-devanagari-fonts",
+        "type_id": "samyak-devanagari",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1064
+},
+{
+    "fields": {
+        "pkgname": "sarai-fonts",
+        "type_id": "sarai",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1065
+},
+{
+    "fields": {
+        "pkgname": "sayonara",
+        "type_id": "sayonara.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1066
+},
+{
+    "fields": {
+        "pkgname": "ibus-sayura",
+        "type_id": "sayura.xml",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1067
+},
+{
+    "fields": {
+        "pkgname": "kipi-plugins",
+        "type_id": "scangui.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Adobe",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1068
+},
+{
+    "fields": {
+        "pkgname": "scap-workbench",
+        "type_id": "scap-workbench.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1069
+},
+{
+    "fields": {
+        "pkgname": "scholarsfonts-cardo-fonts",
+        "type_id": "scholarsfonts-cardo",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1070
+},
+{
+    "fields": {
+        "pkgname": "scidavis",
+        "type_id": "scidavis.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            20,
+            21,
+            26,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1071
+},
+{
+    "fields": {
+        "pkgname": "scilab",
+        "type_id": "scilab.desktop",
+        "keywords": [],
+        "project_license": "CECILL-2.0",
+        "type": "desktop",
+        "categories": [
+            21,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1072
+},
+{
+    "fields": {
+        "pkgname": "scorched3d",
+        "type_id": "scorched3d.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            2,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1073
+},
+{
+    "fields": {
+        "pkgname": "scratch",
+        "type_id": "scratch.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND Apache-2.0 AND MIT AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1074
+},
+{
+    "fields": {
+        "pkgname": "screenie-composer",
+        "type_id": "screenie-composer.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1075
+},
+{
+    "fields": {
+        "pkgname": "scummvm",
+        "type_id": "scummvm.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            73
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1076
+},
+{
+    "fields": {
+        "pkgname": "seaview",
+        "type_id": "seaview.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1077
+},
+{
+    "fields": {
+        "pkgname": "sectool-gui",
+        "type_id": "sectool.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1078
+},
+{
+    "fields": {
+        "pkgname": "senamirmir-washra-fantuwua-fonts",
+        "type_id": "senamirmir-washra",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 1079
+},
+{
+    "fields": {
+        "pkgname": "seq24",
+        "type_id": "seq24.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1080
+},
+{
+    "fields": {
+        "pkgname": "serafettin-cartoon-fonts",
+        "type_id": "serafettin-cartoon",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1081
+},
+{
+    "fields": {
+        "pkgname": "setroubleshoot",
+        "type_id": "setroubleshoot.desktop",
+        "keywords": [
+            2110,
+            2115,
+            2124,
+            2133,
+            2139,
+            2149,
+            2152,
+            10486,
+            10487,
+            10488,
+            10489,
+            10490,
+            10491,
+            10492,
+            10493,
+            10494,
+            10495,
+            10496,
+            10497,
+            10498,
+            10499,
+            10500,
+            10501,
+            10502,
+            10503,
+            10504,
+            10505,
+            10506,
+            10507,
+            10508,
+            10509,
+            10510,
+            10511,
+            10512,
+            10513,
+            10514,
+            10515,
+            10516,
+            10517,
+            10518,
+            10519,
+            10520,
+            10521,
+            10522,
+            10523,
+            10524,
+            10525,
+            10526,
+            10527,
+            10528,
+            10529,
+            10530,
+            10531,
+            10532,
+            10533,
+            10534,
+            10535
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1082
+},
+{
+    "fields": {
+        "pkgname": "sflphone-kde",
+        "type_id": "sflphone-client-kde.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            97
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1083
+},
+{
+    "fields": {
+        "pkgname": "sflphone-gnome",
+        "type_id": "sflphone.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            97
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1084
+},
+{
+    "fields": {
+        "pkgname": "shadowsintolight-fonts",
+        "type_id": "shadowsintolight",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1085
+},
+{
+    "fields": {
+        "pkgname": "calligra-sheets",
+        "type_id": "sheets.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1086
+},
+{
+    "fields": {
+        "pkgname": "shotwell",
+        "type_id": "shotwell.desktop",
+        "keywords": [
+            197,
+            344,
+            876,
+            1121,
+            1584,
+            1585,
+            1586,
+            5405,
+            6636,
+            8135,
+            10536,
+            10537,
+            10538,
+            10539,
+            10540,
+            10541,
+            10542,
+            10543,
+            10544,
+            10545,
+            10546,
+            10547,
+            10548,
+            10549,
+            10550,
+            10551,
+            10552,
+            10553,
+            10554
+        ],
+        "project_license": "LGPL-2.1+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            26,
+            75
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1087
+},
+{
+    "fields": {
+        "pkgname": "digikam",
+        "type_id": "showfoto.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1088
+},
+{
+    "fields": {
+        "pkgname": "shutter",
+        "type_id": "shutter.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1089
+},
+{
+    "fields": {
+        "pkgname": "sidc-gui",
+        "type_id": "sidc_gui.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1090
+},
+{
+    "fields": {
+        "pkgname": "sil-abyssinica-fonts",
+        "type_id": "sil-abyssinica",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1091
+},
+{
+    "fields": {
+        "pkgname": "sil-andika-fonts",
+        "type_id": "sil-andika",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1092
+},
+{
+    "fields": {
+        "pkgname": "sil-charis-fonts",
+        "type_id": "sil-charis",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1093
+},
+{
+    "fields": {
+        "pkgname": "sil-charis-compact-fonts",
+        "type_id": "sil-charis-compact",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1094
+},
+{
+    "fields": {
+        "pkgname": "sil-doulos-fonts",
+        "type_id": "sil-doulos",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1095
+},
+{
+    "fields": {
+        "pkgname": "sil-gentium-fonts",
+        "type_id": "sil-gentium",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1096
+},
+{
+    "fields": {
+        "pkgname": "sil-gentium-basic-book-fonts",
+        "type_id": "sil-gentium-basic",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1097
+},
+{
+    "fields": {
+        "pkgname": "sil-lateef-fonts",
+        "type_id": "sil-lateef",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1098
+},
+{
+    "fields": {
+        "pkgname": "sil-mingzat-fonts",
+        "type_id": "sil-mingzat",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1099
+},
+{
+    "fields": {
+        "pkgname": "sil-nuosu-fonts",
+        "type_id": "sil-nuosu",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1100
+},
+{
+    "fields": {
+        "pkgname": "sil-padauk-book-fonts",
+        "type_id": "sil-padauk",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1101
+},
+{
+    "fields": {
+        "pkgname": "sil-scheherazade-fonts",
+        "type_id": "sil-scheherazade",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1102
+},
+{
+    "fields": {
+        "pkgname": "silkscreen-expanded-fonts",
+        "type_id": "silkscreen",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1103
+},
+{
+    "fields": {
+        "pkgname": "simon",
+        "type_id": "simon.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            38
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1104
+},
+{
+    "fields": {
+        "pkgname": "simple-scan",
+        "type_id": "simple-scan.desktop",
+        "keywords": [
+            800,
+            801,
+            1713,
+            10555,
+            10556,
+            10557,
+            10558,
+            10559,
+            10560,
+            10561,
+            10562,
+            10563,
+            10564,
+            10565,
+            10566,
+            10567,
+            10568,
+            10569,
+            10570,
+            10571,
+            10572,
+            10573,
+            10574,
+            10575,
+            10576,
+            10577,
+            10578,
+            10579,
+            10580,
+            10581,
+            10582,
+            10583,
+            10584,
+            10585,
+            10586,
+            10587,
+            10588
+        ],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            36
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1105
+},
+{
+    "fields": {
+        "pkgname": "simsu",
+        "type_id": "simsu.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1106
+},
+{
+    "fields": {
+        "pkgname": "sir",
+        "type_id": "sir.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1107
+},
+{
+    "fields": {
+        "pkgname": "sj-delphine-fonts",
+        "type_id": "sj-delphine",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1108
+},
+{
+    "fields": {
+        "pkgname": "sj-stevehand-fonts",
+        "type_id": "sj-stevehand",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1109
+},
+{
+    "fields": {
+        "pkgname": "skanlite",
+        "type_id": "skanlite.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 OR GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            26,
+            36
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1110
+},
+{
+    "fields": {
+        "pkgname": "ibus-skk",
+        "type_id": "skk.xml",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1111
+},
+{
+    "fields": {
+        "pkgname": "skychart",
+        "type_id": "skychart.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            69
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1112
+},
+{
+    "fields": {
+        "pkgname": "slic3r",
+        "type_id": "slic3r.desktop",
+        "keywords": [],
+        "project_license": "AGPL-3.0 AND CC-BY-3.0",
+        "type": "desktop",
+        "categories": [
+            26,
+            61
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1113
+},
+{
+    "fields": {
+        "pkgname": "slingshot",
+        "type_id": "slingshot.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1114
+},
+{
+    "fields": {
+        "pkgname": "smb4k",
+        "type_id": "smb4k.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1115
+},
+{
+    "fields": {
+        "pkgname": "smc-anjalioldlipi-fonts",
+        "type_id": "smc",
+        "keywords": [],
+        "project_license": "GPL-3.0-with-GCC-exception",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 1116
+},
+{
+    "fields": {
+        "pkgname": "ax25-tools-x",
+        "type_id": "smdiag.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1117
+},
+{
+    "fields": {
+        "pkgname": "smuxi-frontend-gnome",
+        "type_id": "smuxi-frontend-gnome.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+ AND BSD-3-Clause AND Apache-2.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            70,
+            82,
+            116
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1118
+},
+{
+    "fields": {
+        "pkgname": "snap-gtk",
+        "type_id": "snap.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1119
+},
+{
+    "fields": {
+        "pkgname": "snappy-player",
+        "type_id": "snappy.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7,
+            43,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1120
+},
+{
+    "fields": {
+        "pkgname": "dogtail",
+        "type_id": "sniff.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1121
+},
+{
+    "fields": {
+        "pkgname": "aisleriot",
+        "type_id": "sol.desktop",
+        "keywords": [
+            2201,
+            2224,
+            3892,
+            7564,
+            7609,
+            7611,
+            10589,
+            10590,
+            10591,
+            10592,
+            10593,
+            10594,
+            10595,
+            10596,
+            10597,
+            10598,
+            10599,
+            10600,
+            10601,
+            10602,
+            10603,
+            10604,
+            10605,
+            10606,
+            10607,
+            10608,
+            10609,
+            10610,
+            10611,
+            10612,
+            10613,
+            10614,
+            10615,
+            10616,
+            10617,
+            10618,
+            10619,
+            10620,
+            10621,
+            10622,
+            10623,
+            10624,
+            10625,
+            10626,
+            10627,
+            10628,
+            10629,
+            10630,
+            10631,
+            10632,
+            10633,
+            10634,
+            10635,
+            10636,
+            10637,
+            10638,
+            10639,
+            10640,
+            10641,
+            10642,
+            10643,
+            10644,
+            10645,
+            10646,
+            10647,
+            10648,
+            10649,
+            10650,
+            10651,
+            10652,
+            10653,
+            10654,
+            10655,
+            10656,
+            10657,
+            10658,
+            10659,
+            10660,
+            10661,
+            10662,
+            10663,
+            10664,
+            10665,
+            10666,
+            10667,
+            10668,
+            10669,
+            10670,
+            10671,
+            10672,
+            10673,
+            10674,
+            10675,
+            10676,
+            10677,
+            10678,
+            10679,
+            10680,
+            10681,
+            10682,
+            10683,
+            10684,
+            10685,
+            10686,
+            10687,
+            10688,
+            10689,
+            10690,
+            10691,
+            10692,
+            10693,
+            10694,
+            10695,
+            10696,
+            10697,
+            10698,
+            10699,
+            10700,
+            10701,
+            10702,
+            10703,
+            10704,
+            10705,
+            10706,
+            10707,
+            10708,
+            10709,
+            10710,
+            10711,
+            10712,
+            10713,
+            10714,
+            10715,
+            10716,
+            10717,
+            10718,
+            10719,
+            10720,
+            10721,
+            10722,
+            10723,
+            10724,
+            10725,
+            10726,
+            10727,
+            10728,
+            10729,
+            10730,
+            10731,
+            10732,
+            10733,
+            10734,
+            10735,
+            10736,
+            10737,
+            10738,
+            10739,
+            10740,
+            10741,
+            10742,
+            10743,
+            10744,
+            10745,
+            10746,
+            10747,
+            10748,
+            10749,
+            10750,
+            10751,
+            10752,
+            10753,
+            10754,
+            10755,
+            10756,
+            10757,
+            10758,
+            10759,
+            10760,
+            10761,
+            10762,
+            10763,
+            10764,
+            10765,
+            10766,
+            10767,
+            10768,
+            10769,
+            10770,
+            10771,
+            10772,
+            10773,
+            10774,
+            10775,
+            10776,
+            10777,
+            10778,
+            10779,
+            10780
+        ],
+        "project_license": "GPL-3.0+ AND LGPL-3.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            107
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1122
+},
+{
+    "fields": {
+        "pkgname": "solaar",
+        "type_id": "solaar.desktop",
+        "keywords": [
+            10781,
+            10782,
+            10783,
+            10784,
+            10785
+        ],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1123
+},
+{
+    "fields": {
+        "pkgname": "sonata",
+        "type_id": "sonata.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1124
+},
+{
+    "fields": {
+        "pkgname": "sooperlooper",
+        "type_id": "sooperlooper.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1125
+},
+{
+    "fields": {
+        "pkgname": "sopwith",
+        "type_id": "sopwith.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1126
+},
+{
+    "fields": {
+        "pkgname": "sound-juicer",
+        "type_id": "sound-juicer.desktop",
+        "keywords": [
+            536,
+            7433,
+            7439,
+            10786,
+            10787,
+            10788,
+            10789,
+            10790,
+            10791,
+            10792,
+            10793,
+            10794,
+            10795,
+            10796,
+            10797,
+            10798,
+            10799,
+            10800,
+            10801,
+            10802,
+            10803,
+            10804,
+            10805,
+            10806,
+            10807,
+            10808,
+            10809,
+            10810,
+            10811,
+            10812,
+            10813,
+            10814,
+            10815,
+            10816,
+            10817,
+            10818,
+            10819,
+            10820,
+            10821,
+            10822
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1127
+},
+{
+    "fields": {
+        "pkgname": "soundconverter",
+        "type_id": "soundconverter.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1128
+},
+{
+    "fields": {
+        "pkgname": "adobe-source-sans-pro-fonts",
+        "type_id": "source-sans-pro",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1129
+},
+{
+    "fields": {
+        "pkgname": "sparkleshare",
+        "type_id": "sparkleshare.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1130
+},
+{
+    "fields": {
+        "pkgname": "spatialite-gui",
+        "type_id": "spatialite-gui.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            25
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1131
+},
+{
+    "fields": {
+        "pkgname": "speed-dreams",
+        "type_id": "speed-dreams.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            15
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1132
+},
+{
+    "fields": {
+        "pkgname": "springlobby",
+        "type_id": "springlobby.desktop",
+        "keywords": [
+            1120,
+            2109,
+            2159,
+            2348,
+            2351,
+            10823,
+            10824,
+            10825
+        ],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1133
+},
+{
+    "fields": {
+        "pkgname": "spyder",
+        "type_id": "spyder.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            11,
+            45
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1134
+},
+{
+    "fields": {
+        "pkgname": "sqlitebrowser",
+        "type_id": "sqlitebrowser.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ OR MPL-2.0",
+        "type": "desktop",
+        "categories": [
+            5,
+            11,
+            40
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1135
+},
+{
+    "fields": {
+        "pkgname": "sqliteman",
+        "type_id": "sqliteman.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            11,
+            40
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1136
+},
+{
+    "fields": {
+        "pkgname": "calligra-stage",
+        "type_id": "stage.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1137
+},
+{
+    "fields": {
+        "pkgname": "starcal",
+        "type_id": "starcal2.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            67
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1138
+},
+{
+    "fields": {
+        "pkgname": "stellarium",
+        "type_id": "stellarium.desktop",
+        "keywords": [
+            10826,
+            10827
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            69
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1139
+},
+{
+    "fields": {
+        "pkgname": "stix-fonts",
+        "type_id": "stix",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1140
+},
+{
+    "fields": {
+        "pkgname": "stoken-gui",
+        "type_id": "stoken-gui.desktop",
+        "keywords": [
+            10828,
+            10829,
+            10830
+        ],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            5,
+            68
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1141
+},
+{
+    "fields": {
+        "pkgname": "stormbaancoureur",
+        "type_id": "stormbaancoureur.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            111
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1142
+},
+{
+    "fields": {
+        "pkgname": "streamtuner",
+        "type_id": "streamtuner2.desktop",
+        "keywords": [],
+        "project_license": "Public Domain",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            91
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1143
+},
+{
+    "fields": {
+        "pkgname": "ibus-table-chinese-stroke5",
+        "type_id": "stroke5.db",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1144
+},
+{
+    "fields": {
+        "pkgname": "subscription-manager-gui",
+        "type_id": "subscription-manager-gui.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            51
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1145
+},
+{
+    "fields": {
+        "pkgname": "subsurface",
+        "type_id": "subsurface.desktop",
+        "keywords": [
+            6287,
+            7443,
+            10831,
+            10832,
+            10833,
+            10834
+        ],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1146
+},
+{
+    "fields": {
+        "pkgname": "subtitleeditor",
+        "type_id": "subtitleeditor.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            7,
+            56,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1147
+},
+{
+    "fields": {
+        "pkgname": "sudoku-savant",
+        "type_id": "sudoku-savant.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            1
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1148
+},
+{
+    "fields": {
+        "pkgname": "sumwars",
+        "type_id": "sumwars.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            74
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1149
+},
+{
+    "fields": {
+        "pkgname": "supertux",
+        "type_id": "supertux2.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1150
+},
+{
+    "fields": {
+        "pkgname": "supertuxkart",
+        "type_id": "supertuxkart.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-3.0 AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            12,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1151
+},
+{
+    "fields": {
+        "pkgname": "surf",
+        "type_id": "surf.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            23,
+            52
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1152
+},
+{
+    "fields": {
+        "pkgname": "swami",
+        "type_id": "swami.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            57,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1153
+},
+{
+    "fields": {
+        "pkgname": "swell-foop",
+        "type_id": "swell-foop.desktop",
+        "keywords": [
+            198,
+            200,
+            2163,
+            2164,
+            2165,
+            2167,
+            2168,
+            2171,
+            2172,
+            2174,
+            2175,
+            2176,
+            2177,
+            2179,
+            2180,
+            2182,
+            2183,
+            2185,
+            2186,
+            2189,
+            2190,
+            2191,
+            2192,
+            2195,
+            2196,
+            2198,
+            2199,
+            2200,
+            2201,
+            2203,
+            2204,
+            2207,
+            2208,
+            2210,
+            2211,
+            2212,
+            2213,
+            2214,
+            2216,
+            2217,
+            2219,
+            2220,
+            2223,
+            2224,
+            2226,
+            2227,
+            2228,
+            2229,
+            2230,
+            2231,
+            2233,
+            2235,
+            2236,
+            2237,
+            2239,
+            2242,
+            2243,
+            2252,
+            2253,
+            2254,
+            2255,
+            2259,
+            2260,
+            2262,
+            2263,
+            2264,
+            2265,
+            2267,
+            2268,
+            2269,
+            2272,
+            2273,
+            2275,
+            2276,
+            2278,
+            2279,
+            2281,
+            2282,
+            2284,
+            2286,
+            2287,
+            2288,
+            2290,
+            2292,
+            2293,
+            2294,
+            2296,
+            2298,
+            2300,
+            2301,
+            2303,
+            2304,
+            2680,
+            2953,
+            3768,
+            3769,
+            3772,
+            3774,
+            3779,
+            3782,
+            3784,
+            3785,
+            3787,
+            3790,
+            3792,
+            3794,
+            3795,
+            3799,
+            3803,
+            3806,
+            3812,
+            3813,
+            3817,
+            3820,
+            3821,
+            3824,
+            3825,
+            3829,
+            3832,
+            3833,
+            3835,
+            3837,
+            3839,
+            3841,
+            3843,
+            3846,
+            3848,
+            3849,
+            3851,
+            3853,
+            3859,
+            3861,
+            4129,
+            4145,
+            4159,
+            4364,
+            5102,
+            5105,
+            5106,
+            6217,
+            10835,
+            10836,
+            10837,
+            10838,
+            10839,
+            10840,
+            10841,
+            10842,
+            10843,
+            10844,
+            10845,
+            10846,
+            10847,
+            10848,
+            10849,
+            10850,
+            10851,
+            10852,
+            10853,
+            10854,
+            10855,
+            10856,
+            10857,
+            10858,
+            10859,
+            10860,
+            10861,
+            10862,
+            10863,
+            10864,
+            10865,
+            10866,
+            10867,
+            10868,
+            10869,
+            10870,
+            10871,
+            10872,
+            10873,
+            10874,
+            10875,
+            10876,
+            10877,
+            10878,
+            10879,
+            10880,
+            10881,
+            10882,
+            10883,
+            10884,
+            10885,
+            10886,
+            10887,
+            10888,
+            10889,
+            10890,
+            10891,
+            10892,
+            10893,
+            10894,
+            10895,
+            10896,
+            10897,
+            10898,
+            10899,
+            10900,
+            10901,
+            10902,
+            10903,
+            10904,
+            10905,
+            10906,
+            10907,
+            10908,
+            10909,
+            10910,
+            10911,
+            10912,
+            10913,
+            10914,
+            10915,
+            10916,
+            10917
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1154
+},
+{
+    "fields": {
+        "pkgname": "swift",
+        "type_id": "swift.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            82
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1155
+},
+{
+    "fields": {
+        "pkgname": "sylpheed",
+        "type_id": "sylpheed.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            22,
+            23,
+            24
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1156
+},
+{
+    "fields": {
+        "pkgname": "syncevolution-gtk",
+        "type_id": "sync.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1157
+},
+{
+    "fields": {
+        "pkgname": "synfigstudio",
+        "type_id": "synfigstudio.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            84,
+            88
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1158
+},
+{
+    "fields": {
+        "pkgname": "synthv1",
+        "type_id": "synthv1.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1159
+},
+{
+    "fields": {
+        "pkgname": "sysprof",
+        "type_id": "sysprof.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            66
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1160
+},
+{
+    "fields": {
+        "pkgname": "system-config-httpd",
+        "type_id": "system-config-httpd.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1161
+},
+{
+    "fields": {
+        "pkgname": "system-config-kdump",
+        "type_id": "system-config-kdump.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1162
+},
+{
+    "fields": {
+        "pkgname": "system-config-kickstart",
+        "type_id": "system-config-kickstart.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1163
+},
+{
+    "fields": {
+        "pkgname": "system-config-language",
+        "type_id": "system-config-language.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            51
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1164
+},
+{
+    "fields": {
+        "pkgname": "system-config-printer",
+        "type_id": "system-config-printer.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            51,
+            96,
+            118
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1165
+},
+{
+    "fields": {
+        "pkgname": "system-config-repo",
+        "type_id": "system-config-repo.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1166
+},
+{
+    "fields": {
+        "pkgname": "tabish-eeyek-fonts",
+        "type_id": "tabish-eeyek",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1167
+},
+{
+    "fields": {
+        "pkgname": "tagainijisho",
+        "type_id": "tagainijisho.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            19,
+            46
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1168
+},
+{
+    "fields": {
+        "pkgname": "tagtool",
+        "type_id": "tagtool.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            56
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1169
+},
+{
+    "fields": {
+        "pkgname": "tali",
+        "type_id": "tali.desktop",
+        "keywords": [
+            2183,
+            10918,
+            10919,
+            10920,
+            10921,
+            10922,
+            10923,
+            10924,
+            10925,
+            10926,
+            10927,
+            10928,
+            10929,
+            10930,
+            10931,
+            10932,
+            10933,
+            10934,
+            10935,
+            10936,
+            10937,
+            10938,
+            10939,
+            10940,
+            10941,
+            10942,
+            10943,
+            10944,
+            10945,
+            10946,
+            10947,
+            10948,
+            10949
+        ],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "desktop",
+        "categories": [
+            1,
+            107
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1170
+},
+{
+    "fields": {
+        "pkgname": "tangerine-fonts",
+        "type_id": "tangerine",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1171
+},
+{
+    "fields": {
+        "pkgname": "tanglet",
+        "type_id": "tanglet.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1172
+},
+{
+    "fields": {
+        "pkgname": "taskcoach",
+        "type_id": "taskcoach.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1173
+},
+{
+    "fields": {
+        "pkgname": "tcpjunk",
+        "type_id": "tcpjunk.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1174
+},
+{
+    "fields": {
+        "pkgname": "teeworlds",
+        "type_id": "teeworlds.desktop",
+        "keywords": [],
+        "project_license": "Teeworlds",
+        "type": "desktop",
+        "categories": [
+            1,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1175
+},
+{
+    "fields": {
+        "pkgname": "tellico",
+        "type_id": "tellico.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            13,
+            40
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1176
+},
+{
+    "fields": {
+        "pkgname": "tennix",
+        "type_id": "tennix.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            111
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1177
+},
+{
+    "fields": {
+        "pkgname": "tepsonic",
+        "type_id": "tepsonic.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1178
+},
+{
+    "fields": {
+        "pkgname": "terminator",
+        "type_id": "terminator.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            5,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1179
+},
+{
+    "fields": {
+        "pkgname": "terminology",
+        "type_id": "terminology.desktop",
+        "keywords": [
+            8733,
+            8734,
+            8735,
+            8736
+        ],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1180
+},
+{
+    "fields": {
+        "pkgname": "termit",
+        "type_id": "termit.desktop",
+        "keywords": [
+            10950
+        ],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1181
+},
+{
+    "fields": {
+        "pkgname": "texmaker",
+        "type_id": "texmaker.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1182
+},
+{
+    "fields": {
+        "pkgname": "texstudio",
+        "type_id": "texstudio.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            13,
+            31
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1183
+},
+{
+    "fields": {
+        "pkgname": "texworks",
+        "type_id": "texworks.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1184
+},
+{
+    "fields": {
+        "pkgname": "thai-arundina-fonts-common",
+        "type_id": "thai-arundina",
+        "keywords": [],
+        "project_license": "Bitstream Vera",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 1185
+},
+{
+    "fields": {
+        "pkgname": "thai-scalable-garuda-fonts",
+        "type_id": "thai-scalable-garuda",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1186
+},
+{
+    "fields": {
+        "pkgname": "thai-scalable-kinnari-fonts",
+        "type_id": "thai-scalable-kinnari",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1187
+},
+{
+    "fields": {
+        "pkgname": "thai-scalable-loma-fonts",
+        "type_id": "thai-scalable-loma",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1188
+},
+{
+    "fields": {
+        "pkgname": "thai-scalable-norasi-fonts",
+        "type_id": "thai-scalable-norasi",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1189
+},
+{
+    "fields": {
+        "pkgname": "thai-scalable-purisa-fonts",
+        "type_id": "thai-scalable-purisa",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1190
+},
+{
+    "fields": {
+        "pkgname": "thai-scalable-sawasdee-fonts",
+        "type_id": "thai-scalable-sawasdee",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1191
+},
+{
+    "fields": {
+        "pkgname": "thai-scalable-tlwgmono-fonts",
+        "type_id": "thai-scalable-tlwgmono",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1192
+},
+{
+    "fields": {
+        "pkgname": "thai-scalable-tlwgtypewriter-fonts",
+        "type_id": "thai-scalable-tlwgtypewriter",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1193
+},
+{
+    "fields": {
+        "pkgname": "thai-scalable-tlwgtypist-fonts",
+        "type_id": "thai-scalable-tlwgtypist",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1194
+},
+{
+    "fields": {
+        "pkgname": "thai-scalable-tlwgtypo-fonts",
+        "type_id": "thai-scalable-tlwgtypo",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1195
+},
+{
+    "fields": {
+        "pkgname": "thai-scalable-umpush-fonts",
+        "type_id": "thai-scalable-umpush",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1196
+},
+{
+    "fields": {
+        "pkgname": "thai-scalable-waree-fonts",
+        "type_id": "thai-scalable-waree",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Bitstream Vera",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1197
+},
+{
+    "fields": {
+        "pkgname": "tharlon-fonts",
+        "type_id": "tharlon",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1198
+},
+{
+    "fields": {
+        "pkgname": "thibault-essays1743-fonts",
+        "type_id": "thibault-essay1743",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1199
+},
+{
+    "fields": {
+        "pkgname": "thibault-isabella-fonts",
+        "type_id": "thibault-isabella",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1200
+},
+{
+    "fields": {
+        "pkgname": "thibault-rockets-fonts",
+        "type_id": "thibault-rockets",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1201
+},
+{
+    "fields": {
+        "pkgname": "thibault-staypuft-fonts",
+        "type_id": "thibault-staypuft",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1202
+},
+{
+    "fields": {
+        "pkgname": "tibetan-machine-uni-fonts",
+        "type_id": "tibetan-machine-uni",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1203
+},
+{
+    "fields": {
+        "pkgname": "tiled",
+        "type_id": "tiled.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            26,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1204
+},
+{
+    "fields": {
+        "pkgname": "timeline",
+        "type_id": "timeline.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0 AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1205
+},
+{
+    "fields": {
+        "pkgname": "tintii",
+        "type_id": "tintii.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            26,
+            75
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1206
+},
+{
+    "fields": {
+        "pkgname": "tiresias-fonts-common",
+        "type_id": "tiresias",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "font",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 1207
+},
+{
+    "fields": {
+        "pkgname": "tkabber",
+        "type_id": "tkabber.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            82
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1208
+},
+{
+    "fields": {
+        "pkgname": "tlomt-junction-fonts",
+        "type_id": "tlomt-junction",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1209
+},
+{
+    "fields": {
+        "pkgname": "tlomt-league-gothic-fonts",
+        "type_id": "tlomt-league-gothic",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1210
+},
+{
+    "fields": {
+        "pkgname": "tlomt-orbitron-fonts",
+        "type_id": "tlomt-orbitron",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1211
+},
+{
+    "fields": {
+        "pkgname": "tlomt-sniglet-fonts",
+        "type_id": "tlomt-sniglet",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1212
+},
+{
+    "fields": {
+        "pkgname": "tmw",
+        "type_id": "tmw.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            1
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1213
+},
+{
+    "fields": {
+        "pkgname": "tomahawk",
+        "type_id": "tomahawk.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1214
+},
+{
+    "fields": {
+        "pkgname": "tomboy",
+        "type_id": "tomboy.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+ AND GPL-2.0+ AND MIT",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1215
+},
+{
+    "fields": {
+        "pkgname": "tonto",
+        "type_id": "tonto.desktop",
+        "keywords": [],
+        "project_license": "Artistic-2.0 AND GPL-2.0+ AND BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1216
+},
+{
+    "fields": {
+        "pkgname": "tor-arm-gui",
+        "type_id": "tor-arm.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1217
+},
+{
+    "fields": {
+        "pkgname": "torcs",
+        "type_id": "torcs.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            15
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1218
+},
+{
+    "fields": {
+        "pkgname": "torrent-file-editor",
+        "type_id": "torrent-file-editor.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            77
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1219
+},
+{
+    "fields": {
+        "pkgname": "trustedqsl",
+        "type_id": "tqsl.desktop",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            23,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1220
+},
+{
+    "fields": {
+        "pkgname": "trabajo-fonts",
+        "type_id": "trabajo",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1221
+},
+{
+    "fields": {
+        "pkgname": "tracker-needle",
+        "type_id": "tracker-needle.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1222
+},
+{
+    "fields": {
+        "pkgname": "transmageddon",
+        "type_id": "transmageddon.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            7
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1223
+},
+{
+    "fields": {
+        "pkgname": "transmission-gtk",
+        "type_id": "transmission-gtk.desktop",
+        "keywords": [],
+        "project_license": "MIT AND GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            76,
+            77
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1224
+},
+{
+    "fields": {
+        "pkgname": "transmission-qt",
+        "type_id": "transmission-qt.desktop",
+        "keywords": [],
+        "project_license": "MIT AND GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            76,
+            77
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1225
+},
+{
+    "fields": {
+        "pkgname": "transmission-remote-gtk",
+        "type_id": "transmission-remote-gtk.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            76,
+            77
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1226
+},
+{
+    "fields": {
+        "pkgname": "tremulous",
+        "type_id": "tremulous.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1227
+},
+{
+    "fields": {
+        "pkgname": "tuladha-jejeg-fonts",
+        "type_id": "tuladha-jejeg",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1228
+},
+{
+    "fields": {
+        "pkgname": "tulrich-tuffy-fonts",
+        "type_id": "tulrich-tuffy",
+        "keywords": [],
+        "project_license": "Public Domain",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1229
+},
+{
+    "fields": {
+        "pkgname": "turpial",
+        "type_id": "turpial.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1230
+},
+{
+    "fields": {
+        "pkgname": "tuxanci",
+        "type_id": "tuxanci.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            41,
+            106
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1231
+},
+{
+    "fields": {
+        "pkgname": "tuxcut",
+        "type_id": "tuxcut.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1232
+},
+{
+    "fields": {
+        "pkgname": "tuxpaint",
+        "type_id": "tuxpaint.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            26,
+            106
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1233
+},
+{
+    "fields": {
+        "pkgname": "tuxtype2",
+        "type_id": "tuxtype2.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1234
+},
+{
+    "fields": {
+        "pkgname": "tvtime",
+        "type_id": "tvtime.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            7,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1235
+},
+{
+    "fields": {
+        "pkgname": "ibus-typing-booster",
+        "type_id": "typing-booster.xml",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1236
+},
+{
+    "fields": {
+        "pkgname": "ubuntu-title-fonts",
+        "type_id": "ubuntu-title",
+        "keywords": [],
+        "project_license": "OFL-1.1 OR GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1237
+},
+{
+    "fields": {
+        "pkgname": "ucview",
+        "type_id": "ucview.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            7,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1238
+},
+{
+    "fields": {
+        "pkgname": "udav",
+        "type_id": "udav.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1239
+},
+{
+    "fields": {
+        "pkgname": "ufraw",
+        "type_id": "ufraw.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            75
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1240
+},
+{
+    "fields": {
+        "pkgname": "ugene",
+        "type_id": "ugene.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            19,
+            21
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1241
+},
+{
+    "fields": {
+        "pkgname": "uget",
+        "type_id": "uget-gtk.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            23,
+            76
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1242
+},
+{
+    "fields": {
+        "pkgname": "ukij-tuz-fonts",
+        "type_id": "ukij-tuz",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1243
+},
+{
+    "fields": {
+        "pkgname": "un-core-graphic-fonts",
+        "type_id": "un-core-batang",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1244
+},
+{
+    "fields": {
+        "pkgname": "un-core-gungseo-fonts",
+        "type_id": "un-core-dotum",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1245
+},
+{
+    "fields": {
+        "pkgname": "un-core-pilgi-fonts",
+        "type_id": "un-core-graphic",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1246
+},
+{
+    "fields": {
+        "pkgname": "unetbootin",
+        "type_id": "unetbootin.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1247
+},
+{
+    "fields": {
+        "pkgname": "unifont-fonts",
+        "type_id": "unifont",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND GFDL-1.3",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1248
+},
+{
+    "fields": {
+        "pkgname": "unison240-gtk",
+        "type_id": "unison240.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1249
+},
+{
+    "fields": {
+        "pkgname": "uqm",
+        "type_id": "uqm.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            2,
+            12
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1250
+},
+{
+    "fields": {
+        "pkgname": "urbanlightscape",
+        "type_id": "urbanlightscape.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            75
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1251
+},
+{
+    "fields": {
+        "pkgname": "valyriatear",
+        "type_id": "valyriatear.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            74
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1252
+},
+{
+    "fields": {
+        "pkgname": "vemana2000-fonts",
+        "type_id": "vemana2000",
+        "keywords": [],
+        "project_license": "GPL-2.0-with-font-exception",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1253
+},
+{
+    "fields": {
+        "pkgname": "verbiste-gnome",
+        "type_id": "verbiste.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1254
+},
+{
+    "fields": {
+        "pkgname": "veusz",
+        "type_id": "veusz.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND Python-2.0",
+        "type": "desktop",
+        "categories": [
+            21,
+            28
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1255
+},
+{
+    "fields": {
+        "pkgname": "vidalia",
+        "type_id": "vidalia.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1256
+},
+{
+    "fields": {
+        "pkgname": "viewnior",
+        "type_id": "viewnior.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            14,
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1257
+},
+{
+    "fields": {
+        "pkgname": "viking",
+        "type_id": "viking.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            21,
+            23,
+            25,
+            87
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1258
+},
+{
+    "fields": {
+        "pkgname": "vim-command-t",
+        "type_id": "vim-command-t",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 1259
+},
+{
+    "fields": {
+        "pkgname": "vim-gtk-syntax",
+        "type_id": "vim-gtk-syntax",
+        "keywords": [],
+        "project_license": "Public Domain",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 1260
+},
+{
+    "fields": {
+        "pkgname": "vim-javabrowser",
+        "type_id": "vim-javabrowser",
+        "keywords": [],
+        "project_license": "Vim",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 1261
+},
+{
+    "fields": {
+        "pkgname": "vim-jedi",
+        "type_id": "vim-jedi",
+        "keywords": [],
+        "project_license": "LGPL-3.0",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 1262
+},
+{
+    "fields": {
+        "pkgname": "vim-latex",
+        "type_id": "vim-latex",
+        "keywords": [],
+        "project_license": "Vim",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 1263
+},
+{
+    "fields": {
+        "pkgname": "vim-taglist",
+        "type_id": "vim-taglist",
+        "keywords": [],
+        "project_license": "Vim",
+        "type": "addon",
+        "categories": []
+    },
+    "model": "fedora_software.component",
+    "pk": 1264
+},
+{
+    "fields": {
+        "pkgname": "vimpal",
+        "type_id": "vimpal.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1265
+},
+{
+    "fields": {
+        "pkgname": "vinagre",
+        "type_id": "vinagre.desktop",
+        "keywords": [
+            3611,
+            10951,
+            10952,
+            10953,
+            10954,
+            10955,
+            10956,
+            10957,
+            10958,
+            10959,
+            10960,
+            10961,
+            10962,
+            10963,
+            10964,
+            10965,
+            10966,
+            10967
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            95
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1266
+},
+{
+    "fields": {
+        "pkgname": "virt-manager",
+        "type_id": "virt-manager.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1267
+},
+{
+    "fields": {
+        "pkgname": "virtaal",
+        "type_id": "virtaal.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            104
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1268
+},
+{
+    "fields": {
+        "pkgname": "vlgothic-fonts",
+        "type_id": "vlgothic",
+        "keywords": [],
+        "project_license": "mplus AND BSD-3-Clause",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1269
+},
+{
+    "fields": {
+        "pkgname": "vmpk",
+        "type_id": "vmpk.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            19,
+            57,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1270
+},
+{
+    "fields": {
+        "pkgname": "tigervnc",
+        "type_id": "vncviewer.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            95
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1271
+},
+{
+    "fields": {
+        "pkgname": "vollkorn-fonts",
+        "type_id": "vollkorn",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1272
+},
+{
+    "fields": {
+        "pkgname": "vym",
+        "type_id": "vym.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1273
+},
+{
+    "fields": {
+        "pkgname": "wallpapoz",
+        "type_id": "wallpapoz.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1274
+},
+{
+    "fields": {
+        "pkgname": "wammu",
+        "type_id": "wammu.desktop",
+        "keywords": [
+            1875,
+            1876,
+            1902,
+            1903,
+            1905,
+            1921,
+            1923,
+            1924,
+            1925,
+            1953,
+            2018,
+            2035,
+            2074,
+            2084,
+            2094,
+            2095,
+            6303,
+            8125,
+            10968,
+            10969,
+            10970,
+            10971,
+            10972,
+            10973,
+            10974,
+            10975,
+            10976,
+            10977,
+            10978,
+            10979,
+            10980,
+            10981,
+            10982,
+            10983,
+            10984,
+            10985,
+            10986,
+            10987,
+            10988,
+            10989,
+            10990,
+            10991,
+            10992,
+            10993,
+            10994,
+            10995,
+            10996,
+            10997,
+            10998,
+            10999,
+            11000,
+            11001,
+            11002,
+            11003,
+            11004,
+            11005,
+            11006,
+            11007,
+            11008,
+            11009,
+            11010
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            119
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1275
+},
+{
+    "fields": {
+        "pkgname": "warmux",
+        "type_id": "warmux.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND BSD-3-Clause AND MIT",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1276
+},
+{
+    "fields": {
+        "pkgname": "warzone2100",
+        "type_id": "warzone2100.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1277
+},
+{
+    "fields": {
+        "pkgname": "wesnoth-data",
+        "type_id": "wesnoth.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            2
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1278
+},
+{
+    "fields": {
+        "pkgname": "whaawmp",
+        "type_id": "whaawmp.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43,
+            65
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1279
+},
+{
+    "fields": {
+        "pkgname": "wifi-radar",
+        "type_id": "wifi-radar.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1280
+},
+{
+    "fields": {
+        "pkgname": "wings",
+        "type_id": "wings.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1281
+},
+{
+    "fields": {
+        "pkgname": "winpdb",
+        "type_id": "winpdb.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            42
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1282
+},
+{
+    "fields": {
+        "pkgname": "wireshark-gnome",
+        "type_id": "wireshark.desktop",
+        "keywords": [],
+        "project_license": "GPL-1.0+",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1283
+},
+{
+    "fields": {
+        "pkgname": "woodardworks-laconic-fonts",
+        "type_id": "woodardworks-laconic",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1284
+},
+{
+    "fields": {
+        "pkgname": "wordgroupz",
+        "type_id": "wordgroupz.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            19
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1285
+},
+{
+    "fields": {
+        "pkgname": "calligra-words",
+        "type_id": "words.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1286
+},
+{
+    "fields": {
+        "pkgname": "workrave",
+        "type_id": "workrave.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            38
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1287
+},
+{
+    "fields": {
+        "pkgname": "ibus-table-chinese-wubi-haifeng",
+        "type_id": "wubi-haifeng86.db",
+        "keywords": [],
+        "project_license": "BSD-3-Clause",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1288
+},
+{
+    "fields": {
+        "pkgname": "ibus-table-chinese-wubi-jidian",
+        "type_id": "wubi-jidian86.db",
+        "keywords": [],
+        "project_license": "Freely redistributable without restriction",
+        "type": "inputmethod",
+        "categories": [
+            8,
+            48
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1289
+},
+{
+    "fields": {
+        "pkgname": "wxmacmolplt",
+        "type_id": "wxmacmolplt.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            18,
+            21,
+            26,
+            28,
+            61
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1290
+},
+{
+    "fields": {
+        "pkgname": "wxMaxima",
+        "type_id": "wxmaxima.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11,
+            19,
+            21,
+            27
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1291
+},
+{
+    "fields": {
+        "pkgname": "x-tile",
+        "type_id": "x-tile.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1292
+},
+{
+    "fields": {
+        "pkgname": "xchat-gnome",
+        "type_id": "xchat-gnome.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            70
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1293
+},
+{
+    "fields": {
+        "pkgname": "xchat",
+        "type_id": "xchat.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            70
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1294
+},
+{
+    "fields": {
+        "pkgname": "xemacs",
+        "type_id": "xemacs.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1295
+},
+{
+    "fields": {
+        "pkgname": "xfbib",
+        "type_id": "xfbib.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1296
+},
+{
+    "fields": {
+        "pkgname": "xfburn",
+        "type_id": "xfburn.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            7,
+            53,
+            64
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1297
+},
+{
+    "fields": {
+        "pkgname": "orage",
+        "type_id": "xfcalendar.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            67
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1298
+},
+{
+    "fields": {
+        "pkgname": "xfce4-appfinder",
+        "type_id": "xfce4-appfinder.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1299
+},
+{
+    "fields": {
+        "pkgname": "xfce4-clipman-plugin",
+        "type_id": "xfce4-clipman.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1300
+},
+{
+    "fields": {
+        "pkgname": "xfce4-dict",
+        "type_id": "xfce4-dict.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            13,
+            47,
+            59
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1301
+},
+{
+    "fields": {
+        "pkgname": "xfce4-mixer",
+        "type_id": "xfce4-mixer.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            115
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1302
+},
+{
+    "fields": {
+        "pkgname": "xfce4-notes-plugin",
+        "type_id": "xfce4-notes.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1303
+},
+{
+    "fields": {
+        "pkgname": "xfce4-appfinder",
+        "type_id": "xfce4-run.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1304
+},
+{
+    "fields": {
+        "pkgname": "xfce4-screenshooter",
+        "type_id": "xfce4-screenshooter.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1305
+},
+{
+    "fields": {
+        "pkgname": "xfce4-sensors-plugin",
+        "type_id": "xfce4-sensors.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1306
+},
+{
+    "fields": {
+        "pkgname": "xfce4-taskmanager",
+        "type_id": "xfce4-taskmanager.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            58
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1307
+},
+{
+    "fields": {
+        "pkgname": "xfce4-terminal",
+        "type_id": "xfce4-terminal.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1308
+},
+{
+    "fields": {
+        "pkgname": "xfdashboard",
+        "type_id": "xfdashboard.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1309
+},
+{
+    "fields": {
+        "pkgname": "ax25-tools-x",
+        "type_id": "xfhdlcchpar.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1310
+},
+{
+    "fields": {
+        "pkgname": "ax25-tools-x",
+        "type_id": "xfhdlcsd.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1311
+},
+{
+    "fields": {
+        "pkgname": "ax25-tools-x",
+        "type_id": "xfsmdiag.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1312
+},
+{
+    "fields": {
+        "pkgname": "ax25-tools-x",
+        "type_id": "xfsmmixer.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            23,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1313
+},
+{
+    "fields": {
+        "pkgname": "xgnokii",
+        "type_id": "xgnokii.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            13,
+            67,
+            89,
+            119
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1314
+},
+{
+    "fields": {
+        "pkgname": "hydra-frontend",
+        "type_id": "xhydra.desktop",
+        "keywords": [],
+        "project_license": "AGPL-3.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            68
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1315
+},
+{
+    "fields": {
+        "pkgname": "xiphos-common",
+        "type_id": "xiphos.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            19
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1316
+},
+{
+    "fields": {
+        "pkgname": "xlog",
+        "type_id": "xlog.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            23,
+            72
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1317
+},
+{
+    "fields": {
+        "pkgname": "xmedcon",
+        "type_id": "xmedcon.desktop",
+        "keywords": [],
+        "project_license": "LGPL-2.1+ AND Copyright only AND MIT AND BSD-3-Clause AND libtiff",
+        "type": "desktop",
+        "categories": [
+            26
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1318
+},
+{
+    "fields": {
+        "pkgname": "xmlcopyeditor",
+        "type_id": "xmlcopyeditor.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            11,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1319
+},
+{
+    "fields": {
+        "pkgname": "xmoto",
+        "type_id": "xmoto.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            1,
+            41,
+            111
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1320
+},
+{
+    "fields": {
+        "pkgname": "Xnee",
+        "type_id": "xnee.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1321
+},
+{
+    "fields": {
+        "pkgname": "xonotic",
+        "type_id": "xonotic.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND LGPL-2.1+ AND BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            1,
+            41
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1322
+},
+{
+    "fields": {
+        "pkgname": "xoo",
+        "type_id": "xoo.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            11
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1323
+},
+{
+    "fields": {
+        "pkgname": "xournal",
+        "type_id": "xournal.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1324
+},
+{
+    "fields": {
+        "pkgname": "xpad",
+        "type_id": "xpad.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1325
+},
+{
+    "fields": {
+        "pkgname": "torque-gui",
+        "type_id": "xpbs.desktop",
+        "keywords": [],
+        "project_license": "OpenPBS AND TORQUEv1.1",
+        "type": "desktop",
+        "categories": [
+            19,
+            21,
+            114,
+            120
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1326
+},
+{
+    "fields": {
+        "pkgname": "xpra",
+        "type_id": "xpra_launcher.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+ AND BSD-3-Clause AND LGPL-3.0+ AND MIT",
+        "type": "desktop",
+        "categories": [
+            23
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1327
+},
+{
+    "fields": {
+        "pkgname": "xsane",
+        "type_id": "xsane.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            26,
+            36,
+            71,
+            84
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1328
+},
+{
+    "fields": {
+        "pkgname": "xterm",
+        "type_id": "xterm.desktop",
+        "keywords": [],
+        "project_license": "MIT",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1329
+},
+{
+    "fields": {
+        "pkgname": "yad",
+        "type_id": "yad-icon-browser.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1330
+},
+{
+    "fields": {
+        "pkgname": "yakuake",
+        "type_id": "yakuake.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 OR GPL-3.0",
+        "type": "desktop",
+        "categories": [
+            4,
+            81
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1331
+},
+{
+    "fields": {
+        "pkgname": "yanone-kaffeesatz-fonts",
+        "type_id": "yanone-kaffeesatz",
+        "keywords": [],
+        "project_license": "OFL-1.1",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1332
+},
+{
+    "fields": {
+        "pkgname": "yanone-tagesschrift-fonts",
+        "type_id": "yanone-tagesschrift",
+        "keywords": [],
+        "project_license": "CC-BY-3.0",
+        "type": "font",
+        "categories": [
+            8,
+            9
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1333
+},
+{
+    "fields": {
+        "pkgname": "yarock",
+        "type_id": "yarock.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            43,
+            57
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1334
+},
+{
+    "fields": {
+        "pkgname": "yelp",
+        "type_id": "yelp.desktop",
+        "keywords": [
+            902,
+            904,
+            905,
+            907,
+            908,
+            909,
+            911,
+            912,
+            913,
+            916,
+            918,
+            919,
+            920,
+            922,
+            923,
+            925,
+            926,
+            928,
+            929,
+            930,
+            931,
+            932,
+            933,
+            935,
+            936,
+            940,
+            942,
+            943,
+            944,
+            945,
+            946,
+            948,
+            949,
+            952,
+            953,
+            954,
+            955,
+            957,
+            958,
+            960,
+            961,
+            963,
+            964,
+            965,
+            968,
+            971,
+            973,
+            974,
+            976,
+            977,
+            980,
+            981,
+            983,
+            985,
+            986,
+            987,
+            988,
+            990,
+            991,
+            993,
+            994,
+            995,
+            997,
+            1001,
+            1002,
+            1003,
+            1004,
+            1005,
+            1006,
+            1008,
+            1009,
+            1010,
+            1011,
+            1012,
+            1013,
+            1014,
+            1016,
+            1017,
+            1018,
+            1020,
+            1021,
+            1022,
+            1024,
+            1025,
+            1026,
+            1029,
+            1031,
+            1033,
+            1034,
+            1036,
+            1037,
+            1038,
+            1039,
+            1042,
+            1044,
+            1045,
+            1047,
+            1050,
+            1052,
+            1053,
+            1056,
+            1058,
+            1059,
+            1061,
+            1065,
+            1069,
+            1072,
+            1073,
+            1076,
+            1077,
+            1079,
+            1080,
+            1081,
+            1083,
+            1084,
+            1085,
+            1087,
+            1088,
+            1089,
+            1855,
+            1860,
+            1864,
+            1865,
+            1866,
+            1869,
+            7928,
+            11011,
+            11012,
+            11013,
+            11014,
+            11015,
+            11016,
+            11017,
+            11018,
+            11019,
+            11020,
+            11021,
+            11022,
+            11023,
+            11024,
+            11025,
+            11026,
+            11027,
+            11028,
+            11029,
+            11030,
+            11031,
+            11032,
+            11033,
+            11034,
+            11035,
+            11036,
+            11037,
+            11038,
+            11039,
+            11040,
+            11041,
+            11042,
+            11043,
+            11044,
+            11045,
+            11046,
+            11047,
+            11048,
+            11049,
+            11050,
+            11051,
+            11052,
+            11053,
+            11054,
+            11055,
+            11056,
+            11057,
+            11058,
+            11059,
+            11060,
+            11061,
+            11062,
+            11063,
+            11064,
+            11065,
+            11066,
+            11067,
+            11068,
+            11069,
+            11070,
+            11071,
+            11072,
+            11073,
+            11074,
+            11075,
+            11076,
+            11077,
+            11078,
+            11079,
+            11080,
+            11081,
+            11082,
+            11083,
+            11084,
+            11085,
+            11086,
+            11087,
+            11088,
+            11089,
+            11090
+        ],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            30,
+            85
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1335
+},
+{
+    "fields": {
+        "pkgname": "yoshimi",
+        "type_id": "yoshimi.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            57,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1336
+},
+{
+    "fields": {
+        "pkgname": "yubikey-personalization-gui",
+        "type_id": "yubikey-personalization-gui.desktop",
+        "keywords": [
+            11091,
+            11092
+        ],
+        "project_license": "BSD-3-Clause",
+        "type": "desktop",
+        "categories": [
+            5
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1337
+},
+{
+    "fields": {
+        "pkgname": "yumex-dnf",
+        "type_id": "yumex-dnf.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            51
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1338
+},
+{
+    "fields": {
+        "pkgname": "yumex",
+        "type_id": "yumex.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            4,
+            51
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1339
+},
+{
+    "fields": {
+        "pkgname": "zaz",
+        "type_id": "zaz.desktop",
+        "keywords": [],
+        "project_license": "GPL-3.0+ AND CC-BY-SA-3.0",
+        "type": "desktop",
+        "categories": [
+            1,
+            44
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1340
+},
+{
+    "fields": {
+        "pkgname": "Zim",
+        "type_id": "zim.desktop",
+        "keywords": [
+            6158,
+            10066,
+            11093,
+            11094,
+            11095,
+            11096,
+            11097
+        ],
+        "project_license": "GPL-2.0+ AND LGPL-3.0+",
+        "type": "desktop",
+        "categories": [
+            5,
+            32
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1341
+},
+{
+    "fields": {
+        "pkgname": "zynaddsubfx",
+        "type_id": "zynaddsubfx-alsa.desktop",
+        "keywords": [],
+        "project_license": "GPL-2.0 AND GPL-2.0+",
+        "type": "desktop",
+        "categories": [
+            6,
+            7,
+            78
+        ]
+    },
+    "model": "fedora_software.component",
+    "pk": 1342
+},
+{
+    "fields": {
+        "style": "background: url('/static/images/featured-ardour.png') 30% 49% / 33% no-repeat, url('/static/images/featured-ardour-bg.png') center center / 100% auto no-repeat, linear-gradient(to bottom, #373936, #60625e); stroke: #333333; color: #ffffff; text-shadow: 0 1px 1px rgba(0,0,0,0.5)",
+        "component": 74
+    },
+    "model": "fedora_software.featuredapp",
+    "pk": 1
+},
+{
+    "fields": {
+        "style": "background: url('/static/images/featured-blender.png') 10% 40% / 50% auto no-repeat, -gtk-gradient (radial, center bottom, 0, center center, 1, from(#fcbf83), to(#c06105)); stroke: #783d03; color: #ffffff; text-shadow: 0 1px 1px rgba(0,0,0,0.5)",
+        "component": 121
+    },
+    "model": "fedora_software.featuredapp",
+    "pk": 2
+},
+{
+    "fields": {
+        "style": "background: url('/static/images/featured-firefox.png') 10% center / 40% auto no-repeat, linear-gradient(to bottom, #d3d7cf, #eeeeec); stroke: #babdb6; color: #888a85; text-shadow: 0 1px 1px rgba(255,255,255,0.7)",
+        "component": 329
+    },
+    "model": "fedora_software.featuredapp",
+    "pk": 3
+},
+{
+    "fields": {
+        "style": "background: url('/static/images/featured-gimp.png') left 50% / 50% auto no-repeat, linear-gradient(to bottom, #8ac674, #cbddc3); stroke: #2a6c10; color: #333; text-shadow: 0 1px 1px rgba(255,255,255,0.7)",
+        "component": 448
+    },
+    "model": "fedora_software.featuredapp",
+    "pk": 4
+},
+{
+    "fields": {
+        "style": "background: url('/static/images/featured-inkscape.png') 20% 30% auto no-repeat, linear-gradient(to bottom, #ccd6c3, #a7b797); stroke: #819a6b; color: #ffffff; text-shadow: 0 1px 3px rgba(0,0,0,0.9),0 1px 2px rgba(0,0,0,0.7)",
+        "component": 605
+    },
+    "model": "fedora_software.featuredapp",
+    "pk": 5
+},
+{
+    "fields": {
+        "style": "background: url('/static/images/featured-mypaint.png') left 67% / 50% auto no-repeat, linear-gradient(to bottom, #8fa5d9, #d8e0ef); stroke: #4c52aa; color: #362d89",
+        "component": 821
+    },
+    "model": "fedora_software.featuredapp",
+    "pk": 6
+},
+{
+    "fields": {
+        "style": "background: url('/static/images/featured-weather.png') left 80% / 50% auto no-repeat, url('/static/images/featured-weather-bg.png'), linear-gradient(to bottom, #25486d, #6693ce); stroke: #d8e0ef; color: #ffffff; text-shadow: 0 1px 1px rgba(0,0,0,0.5)",
+        "component": 899
+    },
+    "model": "fedora_software.featuredapp",
+    "pk": 7
+},
+{
+    "fields": {
+        "style": "background: url('/static/images/featured-transmission.png') 10% 20% / 40% auto no-repeat, -gtk-gradient (radial, center bottom, 0, center center, 0.8, from(#ffc124), to(#b75200)); stroke: #a40000; color: #ffffff; text-shadow: 0 1px 1px rgba(0,0,0,0.5)",
+        "component": 1224
+    },
+    "model": "fedora_software.featuredapp",
+    "pk": 8
+},
+{
+    "fields": {
+        "style": "background: url('/static/images/featured-xchat.png') 10% 50% / 40% auto no-repeat, linear-gradient(to bottom, #274c7b, #407cbc); stroke: #407cbc; color: #ffffff; text-shadow: 0 1px 1px rgba(0,0,0,0.5)",
+        "component": 1294
+    },
+    "model": "fedora_software.featuredapp",
+    "pk": 9
+}
+]

--- a/fedora_software/tests.py
+++ b/fedora_software/tests.py
@@ -1,3 +1,116 @@
-from django.test import TestCase
+# ~*~ coding: utf-8 ~*~
 
-# Create your tests here.
+
+"""
+fedora-software
+Unit tests - test.py
+
+This module tests fedora-software's in order to ensure that the various
+parts (units) behave as expected
+"""
+
+from django.conf import settings
+from django.core.urlresolvers import reverse, resolve
+from django.template.loader import render_to_string
+from django.test import TestCase
+from fedora_software.views import HomeView
+from fedora_software.models import Component, FeaturedApp
+
+
+class HelperSuite(TestCase):
+    """
+    Suite which shares common helper methods between various test
+    cases.
+    """
+    def create_sample_component(self, type_id, type_="desktop"):
+        """
+        Helper method created in order to populate the table
+        'Component'
+        """
+        sample_component = Component()
+        sample_component.type = type_
+        sample_component.type_id = type_id
+        sample_component.save()
+        return sample_component
+
+    def create_sample_featured_app(self, component):
+        """
+        Helper method created in order to populate the table
+        'FeaturedApp'
+        """
+        sample_featured_app = FeaturedApp()
+        sample_featured_app.component = component
+        sample_featured_app.save()
+        return sample_featured_app
+
+
+class ViewTest(HelperSuite):
+    """
+    Suite of unit tests performed against views
+    """
+    def test_root_url_resolves_to_home(self):
+        """
+        Tests that the home page's url is correctly resolved
+        """
+        resolved = resolve("/")
+        self.assertEqual(type(resolved.func), type(HomeView.as_view()))
+
+    def test_home_page_returns_correct_html(self):
+        """
+        Tests that the HomeView seems to use the correct template
+        """
+        # this test should be improved and made more useful
+        sample_component = self.create_sample_component(type_id="gimp.desktop")
+        self.create_sample_featured_app(component=sample_component)
+        response = self.client.get(reverse('home'))
+        template_html = render_to_string(
+                'home.html',
+                {"LANGUAGES": settings.LANGUAGES[:]}
+                )
+        self.assertAlmostEqual(
+                len(response.content.decode())/1000,
+                len(template_html)/1000, 
+                )
+
+
+class ModelTest(HelperSuite):
+    """
+    Suite of unit tests performed against models
+    """
+    def test_create_component(self):
+        """
+        Tests the creation of a Component
+        """
+        first_component = Component()
+        first_component.type = "desktop"
+        first_component.type_id = "firefox.desktop"
+        first_component.save()
+
+        second_component = Component()
+        second_component.type = "desktop"
+        second_component.type_id = "xchat.desktop"
+        second_component.save()
+
+        saved_components = Component.objects.all()
+        self.assertEqual(saved_components.count(), 2)
+
+    def test_create_featured_app(self):
+        """
+        Tests the creation of a FeaturedApp
+        """
+        sample_component =self.create_sample_component(
+                type_id="firefox.desktop"
+                )
+        first_featured_app = FeaturedApp()
+        first_featured_app.component = sample_component
+        first_featured_app.save()
+
+        sample_component = self.create_sample_component(
+                type_id="ardour.desktop"
+                )
+        second_featured_app = FeaturedApp()
+        second_featured_app.component = sample_component
+        second_featured_app.save()
+
+        saved_featured_apps = FeaturedApp.objects.all()
+        self.assertEqual(saved_featured_apps.count(), 2)

--- a/functional_tests/test_base.py
+++ b/functional_tests/test_base.py
@@ -1,0 +1,69 @@
+# ~*~ coding: utf-8 ~*~
+
+
+"""
+fedora-software
+Functional tests - test_base.py
+
+This module tests fedora-software's main functionality by user's point
+of view.
+"""
+
+from selenium import webdriver
+from django.test import TestCase
+from fedora_software.models import FeaturedApp
+
+
+class FunctionalTest(TestCase):
+    """
+    Suite of Acceptance tests.
+    """
+    fixtures = ["fedora_software_testing.json"]
+    def setUp(self):
+        """
+        Sets up a testing environment.
+        """
+        self.browser = webdriver.Firefox()
+        self.browser.implicitly_wait(3)
+        self.browser.get("http://localhost:8000")
+
+    def tearDown(self):
+        """
+        Cleans the environment before testing.
+        """
+        self.browser.quit()
+
+    def test_if_fedora_software_is_reachable(self):
+        """
+        Checks if the browser is able to reach fedora-software
+        """
+        # Kathe is the user of our example. She has heard about a new
+        # exciting software for her Fedora's workstation. She visits it
+        # via Firefox.
+
+        # She notices the page title mention 'Fedora-Software'
+        self.assertIn("Welcome to Fedora Software", self.browser.title)
+
+    def test_if_featured_apps_are_displayed_correctly(self):
+        """
+        Tests if the featured apps are correctly displayed on the home
+        """
+        # She also see a section which seems to contain some packages
+        # listed as 'Featured apps'.
+        featured_header_text = self.browser.find_element_by_tag_name('h1').text
+        self.assertEqual("Featured apps", featured_header_text)
+
+        # She notices that there some apps appears randomly
+        app_link = self.browser.find_element_by_id("featured_app_href")
+        app_link = app_link.get_attribute("href")
+        app_pkgname = "None"
+
+        i = 0
+        for app in FeaturedApp.objects.all():
+            app_name_from_link = app_link.split("/apps/")[1]
+            if app_name_from_link in app.component.type_id:
+                app_type_id = app.component.type_id
+                break
+
+        self.assertIn(app_name_from_link, app_type_id)
+


### PR DESCRIPTION
Hi guys.

First of all, as I said via mail to Jozef, I really like the idea behind this project.
Since I saw that fedora-software is currently missing automated tests, I've started writing some code.

The approach I'm following is that we may call "outside-in". The steps are the following:
1) Write a sort of storyline by user's point of view, starting from the main pages and details.
2) Write functional - also called acceptance - tests in order to simulate the user's interaction.
3) Write unit tests, in order to tests the behavior of the software on a lower level.

Functional tests are located on "functional_tests/test_base.py" whereas the most appropriate place for unit tests is "fedora_software/tests.py".
We might split them and organize the folder following features nor GitHub's issues, but it's not required at this point, since the TestCases are few.

For now, I've written these tests:
1) Steps for Selenium in order to open the home page.
2) A functional test in order to test if the Featured Apps appear on the home page.
3) Some unit tests related to HomeView, FeaturedApp and Component

I know the coverage is still low, but this is a starting point and I hope to write other cases soon.

In order to run the full testing suite, you should follow these steps:
1) Install firefox and selenium
2) Run Django's Webserver on the standard port (8000)
3) python manage.py test

Have a nice week-end

---

Giulio

GitHub: pigjuliux
FAS: juliuxpigface
Member of: FedoraQA
